### PR TITLE
Add support for extravars in imperative jobs

### DIFF
--- a/clustergroup/templates/imperative/job.yaml
+++ b/clustergroup/templates/imperative/job.yaml
@@ -58,6 +58,10 @@ spec:
                 {{- end }}
                 - -e
                 - "@/values/values.yaml"
+                {{- range .extravars }}
+                - -e
+                - {{ . | quote }}
+                {{- end }}
                 - {{ .playbook }}
               volumeMounts:
               - name: git


### PR DESCRIPTION
Tested with the following:
- name: vault-unseal
  playbook: common/ansible/playbooks/vault/vault.yaml
  tags: "vault_init,vault_unseal,vault_secrets_init"
  extravars:
    - '{"file_unseal": false}'
  disabled: true
