### PR TITLE
Align the argo policy

### DIFF
--- a/clustergroup/templates/argocd.yaml
+++ b/clustergroup/templates/argocd.yaml
@@ -68,7 +68,10 @@ spec:
         memory: 128Mi
   initialSSHKnownHosts: {}
   rbac:
-    defaultPolicy: role:admin
+    policy: |
+      g, system:cluster-admins, role:admin
+      g, cluster-admins, role:admin
+    scopes: '[groups]'
   repo:
     resources:
       limits:

--- a/tests/clustergroup-naked.expected.yaml
+++ b/tests/clustergroup-naked.expected.yaml
@@ -126,7 +126,10 @@ spec:
         memory: 128Mi
   initialSSHKnownHosts: {}
   rbac:
-    defaultPolicy: role:admin
+    policy: |
+      g, system:cluster-admins, role:admin
+      g, cluster-admins, role:admin
+    scopes: '[groups]'
   repo:
     resources:
       limits:

--- a/tests/clustergroup-normal.expected.yaml
+++ b/tests/clustergroup-normal.expected.yaml
@@ -594,7 +594,10 @@ spec:
         memory: 128Mi
   initialSSHKnownHosts: {}
   rbac:
-    defaultPolicy: role:admin
+    policy: |
+      g, system:cluster-admins, role:admin
+      g, cluster-admins, role:admin
+    scopes: '[groups]'
   repo:
     resources:
       limits:


### PR DESCRIPTION
This should align the argocd rbac policy for namespaced instances to the
same as the main argo instance.

This was initially pushed via 3ee9bb64127081520050e502e497e55056bfa41a
in multicluster-devsecops. Since it is for common/ let's place it in the
proper repo.
