### PR TITLE
Add --pull=newer when running the container

### DIFF
--- a/scripts/pattern-util.sh
+++ b/scripts/pattern-util.sh
@@ -27,7 +27,7 @@ fi
 
 # Do not quote the ${KUBECONF_ENV} below, otherwise we will pass '' to podman
 # which will be confused
-podman run -it --rm \
+podman run -it --rm --pull=newer \
 	--security-opt label=disable \
 	-e EXTRA_HELM_OPTS \
 	-e KUBECONFIG \


### PR DESCRIPTION
From https://docs.podman.io/en/latest/markdown/podman-run.1.html#pull-policy

Pull image policy. The default is missing.

    always: Always pull the image and throw an error if the pull fails.
    missing: Pull the image only if it could not be found in the local
             containers storage. Throw an error if no image could be found and
             the pull fails.
    never: Never pull the image but use the one from the local containers
           storage. Throw an error if no image could be found.
    newer: Pull if the image on the registry is newer than the one in
           the local containers storage. An image is considered to be newer
           when the digests are different. Comparing the time stamps is prone
           to errors. Pull errors are suppressed if a local image was found.

Switching to pull=newer will allow us to keep this image uptodate for
users without erroring out if podman cannot check or pull a new image
(i.e. we'd keep running the local one)
