### PR TITLE
Add docker.io to the whitelisted registries when loading an IIB

### DIFF
--- a/ansible/roles/iib_ci/tasks/setup-internal-registry.yml
+++ b/ansible/roles/iib_ci/tasks/setup-internal-registry.yml
@@ -45,7 +45,7 @@
 
 - name: Set registry allowedRegistries
   ansible.builtin.shell: >
-    oc patch image.config.openshift.io/cluster --patch "{\"spec\":{\"registrySources\":{\"allowedRegistries\":[ \"registry.stage.redhat.io\", \"registry.access.redhat.com\", \"registry.connect.redhat.com\", \"ghcr.io\", \"gcr.io\", \"quay.io\", \"registry.redhat.io\",
+    oc patch image.config.openshift.io/cluster --patch "{\"spec\":{\"registrySources\":{\"allowedRegistries\":[ \"registry.stage.redhat.io\", \"registry.access.redhat.com\", \"registry.connect.redhat.com\", \"ghcr.io\", \"gcr.io\", \"quay.io\", \"registry.redhat.io\", \"docker.io\",
     \"registry-proxy.engineering.redhat.com\", \"image-registry.openshift-image-registry.svc:5000\", \"{{ registry_route }}\"]}}}" --type=merge
 
 - name: Set registry insecureRegistries


### PR DESCRIPTION
Medical diagnosis for example uses docker.io/obsidiandynamics/kafdrop:latest
which would be denied by policy.
