### PR TITLE
Add workflow to split helm charts into their own repo

### DIFF
--- a/.github/workflows/chart-branches.yml
+++ b/.github/workflows/chart-branches.yml
@@ -1,0 +1,117 @@
+---
+name: Create per-chart branches
+
+# We only run this job on the charts that will be later moved to full blown charts
+# We also want to run the subtree comand only for the charts that have been actually changed
+# because git subtree split is a bit of an expensive operation
+# github actions do not support yaml anchors so there is more duplication than usual
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'acm/**'
+      - 'golang-external-secrets/**'
+      - 'hashicorp-vault/**'
+      - 'letsencrypt/**'
+      - 'clustergroup/**'
+
+jobs:
+  changes:
+    name: Figure out per-chart changes
+    runs-on: ubuntu-latest
+    permissions: read-all
+    outputs:
+      acm: ${{ steps.filter.outputs.acm }}
+      golang-external-secrets: ${{ steps.filter.outputs.golang-external-secrets }}
+      hashicorp-vault: ${{ steps.filter.outputs.hashicorp-vault }}
+      letsencrypt: ${{ steps.filter.outputs.letsencrypt }}
+      clustergroup: ${{ steps.filter.outputs.clustergroup }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            acm:
+              - 'acm/**'
+            golang-external-secrets:
+              - 'golang-external-secrets/**'
+            hashicorp-vault:
+              - 'hashicorp-vault/**'
+            letsencrypt:
+              - 'letsencrypt/**'
+            clustergroup:
+              - 'clustergroup/**'
+
+  acm:
+    needs: changes
+    if: ${{ needs.changes.outputs.acm == 'true' }}
+    uses: validatedpatterns/common/.github/workflows/chart-split.yml@main
+    permissions:
+      actions: write
+      contents: write
+    with:
+      chart_name: acm
+      upstream_repository: validatedpatterns/common
+      target_repository: validatedpatterns/acm-chart
+      force: true
+    secrets: inherit
+
+  golang-external-secrets:
+    needs: changes
+    if: ${{ needs.changes.outputs.golang-external-secrets == 'true' }}
+    uses: validatedpatterns/common/.github/workflows/chart-split.yml@main
+    permissions:
+      actions: write
+      contents: write
+    with:
+      chart_name: golang-external-secrets
+      upstream_repository: validatedpatterns/common
+      target_repository: validatedpatterns/golang-external-secrets-chart
+      force: true
+    secrets: inherit
+
+  hashicorp-vault:
+    needs: changes
+    if: ${{ needs.changes.outputs.hashicorp-vault == 'true' }}
+    uses: validatedpatterns/common/.github/workflows/chart-split.yml@main
+    permissions:
+      actions: write
+      contents: write
+    with:
+      chart_name: hashicorp-vault
+      upstream_repository: validatedpatterns/common
+      target_repository: validatedpatterns/hashicorp-vault-chart
+      force: true
+    secrets: inherit
+
+  letsencrypt:
+    needs: changes
+    if: ${{ needs.changes.outputs.letsencrypt == 'true' }}
+    uses: validatedpatterns/common/.github/workflows/chart-split.yml@main
+    permissions:
+      actions: write
+      contents: write
+    with:
+      chart_name: letsencrypt
+      upstream_repository: validatedpatterns/common
+      target_repository: validatedpatterns/letsencrypt-chart
+      force: true
+    secrets: inherit
+
+  clustergroup:
+    needs: changes
+    if: ${{ needs.changes.outputs.clustergroup == 'true' }}
+    uses: validatedpatterns/common/.github/workflows/chart-split.yml@main
+    permissions:
+      actions: write
+      contents: write
+    with:
+      chart_name: clustergroup
+      upstream_repository: validatedpatterns/common
+      target_repository: validatedpatterns/clustergroup-chart
+      force: true
+    secrets: inherit

--- a/.github/workflows/chart-split.yml
+++ b/.github/workflows/chart-split.yml
@@ -1,0 +1,61 @@
+---
+name: Split into chart repo branches
+
+on:
+  workflow_call:
+    inputs:
+      chart_name:
+        required: true
+        type: string
+      upstream_repository:
+        required: true
+        type: string
+      target_repository:
+        required: true
+        type: string
+      target_branch:
+        required: false
+        type: string
+        default: main
+      force:
+        required: false
+        type: boolean
+        default: false
+      tags:
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  split_chart:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: write
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.CHARTS_REPOS_TOKEN }}
+
+      - name: Run git subtree split
+        env:
+          GITHUB_TOKEN: ${{ secrets.CHARTS_REPOS_TOKEN }}
+        run: |
+          set -e
+          N=${{ inputs.chart_name }}
+          B="${N}-main-single-chart"
+          git push origin -d "${B}" || /bin/true
+          git subtree split -P "${N}" -b "${B}"
+          git push -f -u origin "${B}"
+
+      - uses: TobKed/github-forks-sync-action@master
+        with:
+          github_token: ${{ secrets.CHARTS_REPOS_TOKEN }}
+          upstream_repository: ${{ inputs.upstream_repository }}
+          upstream_branch: "${{ inputs.chart_name }}-main-single-chart"
+          target_repository: ${{ inputs.target_repository }}
+          target_branch: ${{ inputs.target_branch }}
+          force: ${{ inputs.force }}
+          tags: ${{ inputs.tags }}


### PR DESCRIPTION
This will push any change done to a chart folder out into the separate
repo corresponding to the chart that has been changed.

This workflow needs a secret called CHARTS_REPOS_TOKEN that is a
Personal Access Token with fine grained repo and workflow write access
on the following repos:

  - acm-chart
  - hashicorp-vault-chart
  - golang-external-secrets-chart
  - clustergroup-chart
  - letsencrypt-chart
