### PR TITLE
Add initial multi-source support

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,9 @@
 # Changes
 
+## Aug 17, 2023
+
+* Introduced support for multisource applications via .chart + .chartVersion
+
 ## Jul 8, 2023
 
 * Introduced a default of 20 for sync failures retries in argo applications (global override via global.options.applicationRetryLimit

--- a/clustergroup/templates/_helpers.tpl
+++ b/clustergroup/templates/_helpers.tpl
@@ -45,3 +45,26 @@ Default always defined valueFiles to be included in Applications
 {{- end }} {{/* range $.Values.global.extraValueFiles */}}
 {{- end }} {{/* if $.Values.global.extraValueFiles */}}
 {{- end }} {{/* clustergroup.app.globalvalues.valuefiles */}}
+
+{{/*
+Default always defined valueFiles to be included in Applications but with a prefix called $patternref
+*/}}
+{{- define "clustergroup.app.globalvalues.prefixedvaluefiles" -}}
+- "$patternref/values-global.yaml"
+- "$patternref/values-{{ $.Values.clusterGroup.name }}.yaml"
+{{- if $.Values.global.clusterPlatform }}
+- "$patternref/values-{{ $.Values.global.clusterPlatform }}.yaml"
+  {{- if $.Values.global.clusterVersion }}
+- "$patternref/values-{{ $.Values.global.clusterPlatform }}-{{ $.Values.global.clusterVersion }}.yaml"
+  {{- end }}
+- "$patternref/values-{{ $.Values.global.clusterPlatform }}-{{ $.Values.clusterGroup.name }}.yaml"
+{{- end }}
+{{- if $.Values.global.clusterVersion }}
+- "$patternref/values-{{ $.Values.global.clusterVersion }}-{{ $.Values.clusterGroup.name }}.yaml"
+{{- end }}
+{{- if $.Values.global.extraValueFiles }}
+{{- range $.Values.global.extraValueFiles }}
+- "$patternref/{{ . }}"
+{{- end }} {{/* range $.Values.global.extraValueFiles */}}
+{{- end }} {{/* if $.Values.global.extraValueFiles */}}
+{{- end }} {{/* clustergroup.app.globalvalues.prefixedvaluefiles */}}

--- a/clustergroup/templates/plumbing/applications.yaml
+++ b/clustergroup/templates/plumbing/applications.yaml
@@ -128,6 +128,72 @@ spec:
     name: {{ $.Values.clusterGroup.targetCluster }}
     namespace: {{ default $namespace .namespace }}
   project: {{ .project }}
+  {{- if and .chart .chartVersion }} {{- /* if .chartVersion is set *and* .repoURL is undefined we assume this is a multisource app */}}
+  sources:
+    - repoURL: {{ coalesce .repoURL $.Values.global.repoURL }}
+      {{- /* We do not allow overriding the values with .targetRevision because when we use .targetRevision in a chart to specify the helm
+             chart, that revision (e.g. 0.0.1) won't exist in the git tree. So here we simply always take the pattern's git branch/commit */}}
+      targetRevision: {{ $.Values.global.targetRevision }}
+      ref: patternref
+    - repoURL: {{ coalesce .repoURL $.Values.global.multiSourceRepoUrl }}
+      chart: {{ .chart }}
+      targetRevision: {{ .chartVersion }}
+      {{- if .plugin }}
+      plugin: {{ .plugin | toPrettyJson }}
+      {{- else }}
+      helm:
+        ignoreMissingValueFiles: true
+        valueFiles:
+        {{- include "clustergroup.app.globalvalues.prefixedvaluefiles" $ | nindent 8 }}
+        {{- range $valueFile := .extraValueFiles }}
+        - {{ $valueFile | quote }}
+        {{- end }}
+        parameters:
+          {{- include "clustergroup.app.globalvalues.helmparameters" $ | nindent 8 }}
+          {{- range .extraHubClusterDomainFields }}
+          - name: {{ . }}
+            value: {{ $.Values.global.hubClusterDomain }}
+          {{- end }}
+          {{- range .extraLocalClusterDomainFields }}
+          - name: {{ . }}
+            value: {{ $.Values.global.localClusterDomain }}
+          {{- end }}
+          {{- range .extraRepoURLFields }}
+          - name: {{ . }}
+            value: $ARGOCD_APP_SOURCE_REPO_URL
+          {{- end }}
+          {{- range .extraTargetRevisionFields }}
+          - name: {{ . }}
+            value: $ARGOCD_APP_SOURCE_TARGET_REVISION
+          {{- end }}
+          {{- range .extraNamespaceFields }}
+          - name: {{ . }}
+            value: $ARGOCD_APP_NAMESPACE
+          {{- end }}
+          {{- range .extraPatternNameFields }}
+          - name: {{ . }}
+            value: {{ $.Values.global.pattern }}
+          {{- end }}
+          {{- range $k, $v := $.Values.extraParametersNested }}
+          - name: {{ $k }}
+            value: {{ $v }}
+          {{- end }}
+          {{- range .overrides }}
+          - name: {{ .name }}
+            value: {{ .value | quote }}
+          {{- if .forceString }}
+            forceString: true
+          {{- end }}
+          {{- end }}{{- /* range .overrides */}}
+        {{- if .fileParameters }}
+        fileParameters:
+        {{- range .fileParameters }}
+          - name: {{ .name }}
+            path: {{ .path }}
+        {{- end }}
+        {{- end }}{{- /* if .fileParameters */}}
+      {{- end }}{{- /* if .plugin */}}
+  {{- else }} {{- /* if .chartVersion */}}
   source:
     repoURL: {{ coalesce .repoURL $.Values.global.repoURL }}
     targetRevision: {{ coalesce .targetRevision $.Values.global.targetRevision }}
@@ -191,6 +257,7 @@ spec:
       {{- end }}{{- /* range .fileParameters */}}
       {{- end }}{{- /* if .fileParameters */}}
     {{- end }}{{- /* if .plugin */}}
+  {{- end }}{{- /* if .chartVersion */}}
   {{- if .ignoreDifferences }}
   ignoreDifferences: {{ .ignoreDifferences | toPrettyJson }}
   {{- end }}

--- a/clustergroup/values.schema.json
+++ b/clustergroup/values.schema.json
@@ -388,6 +388,10 @@
           "type": "string",
           "description": "Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo."
         },
+        "chartVersion": {
+          "type": "string",
+          "description": "The version of the helm chart to be used. Can be a regex like '0.0.*'."
+        },
         "kustomize": {
           "type": "boolean",
           "description": "If set to true it will tell ArgoCD to use kustomize to deploy the application."


### PR DESCRIPTION
This change adds initial multiSource support to patterns' applications.
The way this works is that nothing changes for applications defined in
values-*.yaml by default. So all patterns will work as usual.

What can change with this patch is that applications can slowly migrate
towards using multi source by changing an app definition from:

    acm:
      name: acm
      path: common/acm

To:

    acm:
      name: acm
      chart: acm
      chartVersion: 0.0.*

So any time we have a `chart` field with a `chartVersion` and no
`repoURL` defined, the clustergroup chart will create a multisource
application with the values files taken from the patterns git repo
and the helm chart from https://charts.validatedpatterns.io/ using
the `chartVersion` defined in the application.

For example the above acm app would prodice the following:

    project: hub
    sources:
    - ref: patternref
      repoURL: https://github.com/mbaldessari/multicloud-gitops
      targetRevision: multisource-test2
    - chart: acm
      helm:
        ignoreMissingValueFiles: true
        parameters:
        - name: global.repoURL
          value: $ARGOCD_APP_SOURCE_REPO_URL
        - name: global.targetRevision
          value: $ARGOCD_APP_SOURCE_TARGET_REVISION
        - name: global.namespace
          value: $ARGOCD_APP_NAMESPACE
        - name: global.pattern
          value: pattern-sample
        - name: global.clusterDomain
          value: mcg-hub.blueprints.rhecoeng.com
        - name: global.clusterVersion
          value: "4.13"
        - name: global.clusterPlatform
          value: AWS
        - name: global.hubClusterDomain
          value: apps.mcg-hub.blueprints.rhecoeng.com
        - name: global.localClusterDomain
          value: apps.mcg-hub.blueprints.rhecoeng.com
        valueFiles:
        - $patternref/values-global.yaml
        - $patternref/values-hub.yaml
        - $patternref/values-AWS.yaml
        - $patternref/values-AWS-4.13.yaml
        - $patternref/values-AWS-hub.yaml
        - $patternref/values-4.13-hub.yaml
      repoURL: https://charts.validatedpatterns.io/
      targetRevision: 0.0.*

Note that this depends on the operator supporting multiSource
applications (version > 0.0.17).
