### PR TITLE
Drop vault.ui.serviceType: "LoadBalancer"

### DIFF
--- a/hashicorp-vault/values.yaml
+++ b/hashicorp-vault/values.yaml
@@ -8,7 +8,6 @@ vault:
     enabled: false
   ui:
     enabled: true
-    serviceType: "LoadBalancer"
   server:
     extraEnvironmentVars:
       VAULT_CACERT: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt

--- a/tests/hashicorp-vault-industrial-edge-factory.expected.yaml
+++ b/tests/hashicorp-vault-industrial-edge-factory.expected.yaml
@@ -140,8 +140,7 @@ spec:
     - name: http
       port: 8200
       targetPort: 8200
-  type: LoadBalancer
-  externalTrafficPolicy: Cluster
+  type: ClusterIP
 ---
 # Source: hashicorp-vault/charts/vault/templates/server-statefulset.yaml
 # StatefulSet to run the actual vault server cluster.

--- a/tests/hashicorp-vault-industrial-edge-hub.expected.yaml
+++ b/tests/hashicorp-vault-industrial-edge-hub.expected.yaml
@@ -140,8 +140,7 @@ spec:
     - name: http
       port: 8200
       targetPort: 8200
-  type: LoadBalancer
-  externalTrafficPolicy: Cluster
+  type: ClusterIP
 ---
 # Source: hashicorp-vault/charts/vault/templates/server-statefulset.yaml
 # StatefulSet to run the actual vault server cluster.

--- a/tests/hashicorp-vault-medical-diagnosis-hub.expected.yaml
+++ b/tests/hashicorp-vault-medical-diagnosis-hub.expected.yaml
@@ -140,8 +140,7 @@ spec:
     - name: http
       port: 8200
       targetPort: 8200
-  type: LoadBalancer
-  externalTrafficPolicy: Cluster
+  type: ClusterIP
 ---
 # Source: hashicorp-vault/charts/vault/templates/server-statefulset.yaml
 # StatefulSet to run the actual vault server cluster.

--- a/tests/hashicorp-vault-naked.expected.yaml
+++ b/tests/hashicorp-vault-naked.expected.yaml
@@ -140,8 +140,7 @@ spec:
     - name: http
       port: 8200
       targetPort: 8200
-  type: LoadBalancer
-  externalTrafficPolicy: Cluster
+  type: ClusterIP
 ---
 # Source: hashicorp-vault/charts/vault/templates/server-statefulset.yaml
 # StatefulSet to run the actual vault server cluster.

--- a/tests/hashicorp-vault-normal.expected.yaml
+++ b/tests/hashicorp-vault-normal.expected.yaml
@@ -140,8 +140,7 @@ spec:
     - name: http
       port: 8200
       targetPort: 8200
-  type: LoadBalancer
-  externalTrafficPolicy: Cluster
+  type: ClusterIP
 ---
 # Source: hashicorp-vault/charts/vault/templates/server-statefulset.yaml
 # StatefulSet to run the actual vault server cluster.


### PR DESCRIPTION
It is not needed and it adds a requirement to the cluster to have a
proper LadBalancer which is not always the case.

The default in the helm chart is "ClusterIP", so let's leave that
default.

Tested this on an OCP 4.13 SNO cluster (without LB) and the UI is
correctly accessible.
