### PR TITLE
Add support for passing EXTRA_HELM_OPTS

### DIFF
--- a/scripts/pattern-util.sh
+++ b/scripts/pattern-util.sh
@@ -36,6 +36,7 @@ fi
 # which will be confused
 podman run -it --rm \
 	--security-opt label=disable \
+	-e EXTRA_HELM_OPTS \
 	${KUBECONF_ENV} \
 	-v "${HOME}":"${HOME}" \
 	-v "${HOME}":/pattern-home \


### PR DESCRIPTION
Currently a user can set additional helm params via the
EXTRA_HELM_OPTS environment variable in order to tweak a value at `make
install` time.

This does not work correctly when we run things from our utility
container, that is because that variable is never passed from the host
to the container.

According to `man podman run` if we simply pass `-e EXTRA_HELM_OPTS` to
the podman invocation: "If an environment variable is spec‐
ified without a value, Podman checks the host environment for a value
and set the variable only if it is set on the host"

* Without setting EXTRA_HELM_OPTS:

    unset EXTRA_HELM_OPTS; ./pattern.sh make install
    make -f common/Makefile operator-deploy
    make[1]: Entering directory '/home/michele/Engineering/cloud-patterns/multicloud-gitops'
    Checking prerequisites:
      Check for 'git helm oc ansible': OK
      Check for python-kubernetes: OK
      Check for kubernetes.core collection: OK
    Checking repository:
      https://github.com/mbaldessari/multicloud-gitops.git - branch main: Running inside a container: Skipping git ssh checks
    + oc get crds patterns.gitops.hybrid-cloud-patterns.io
    + echo 'Running helm:'
    Running helm:
    + helm upgrade --install multicloud-gitops common/operator-install/ -f values-global.yaml --set main.git.repoURL=https://github.com/mbaldessari/multicloud-gitops.git --set main.git.revision=main

* With EXTRA_HELM_OPTS set:

    export EXTRA_HELM_OPTS="--set main.multiSourceConfig.enabled=true"; ./pattern.sh make install
    make -f common/Makefile operator-deploy
    make[1]: Entering directory '/home/michele/Engineering/cloud-patterns/multicloud-gitops'
    Checking prerequisites:
      Check for 'git helm oc ansible': OK
      Check for python-kubernetes: OK
      Check for kubernetes.core collection: OK
    Checking repository:
      https://github.com/mbaldessari/multicloud-gitops.git - branch main: Running inside a container: Skipping git ssh checks
    + oc get crds patterns.gitops.hybrid-cloud-patterns.io
    + echo 'Running helm:'
    Running helm:
    + helm upgrade --install multicloud-gitops common/operator-install/ -f values-global.yaml --set main.git.repoURL=https://github.com/mbaldessari/multicloud-gitops.git --set main.git.revision=main --set main.multiSourceConfig.enabled=true

(Briefly added set -x to see the exact commands during testing)
