### PR TITLE
Adding label validatedpatterns.io/pattern to all applications.

### DIFF
--- a/clustergroup/templates/plumbing/applications.yaml
+++ b/clustergroup/templates/plumbing/applications.yaml
@@ -121,6 +121,8 @@ kind: Application
 metadata:
   name: {{ .name }}
   namespace: {{ $namespace }}
+  labels:
+    validatedpatterns.io/pattern: {{ $.Values.global.pattern }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io/foreground
 spec:

--- a/tests/clustergroup-industrial-edge-factory.expected.yaml
+++ b/tests/clustergroup-industrial-edge-factory.expected.yaml
@@ -368,6 +368,8 @@ kind: Application
 metadata:
   name: stormshift
   namespace: mypattern-factory
+  labels:
+    validatedpatterns.io/pattern: mypattern
   finalizers:
   - resources-finalizer.argocd.argoproj.io/foreground
 spec:
@@ -393,6 +395,8 @@ kind: Application
 metadata:
   name: odh
   namespace: mypattern-factory
+  labels:
+    validatedpatterns.io/pattern: mypattern
   finalizers:
   - resources-finalizer.argocd.argoproj.io/foreground
 spec:

--- a/tests/clustergroup-industrial-edge-hub.expected.yaml
+++ b/tests/clustergroup-industrial-edge-hub.expected.yaml
@@ -668,6 +668,8 @@ kind: Application
 metadata:
   name: acm
   namespace: mypattern-datacenter
+  labels:
+    validatedpatterns.io/pattern: mypattern
   finalizers:
   - resources-finalizer.argocd.argoproj.io/foreground
 spec:
@@ -723,6 +725,8 @@ kind: Application
 metadata:
   name: odh
   namespace: mypattern-datacenter
+  labels:
+    validatedpatterns.io/pattern: mypattern
   finalizers:
   - resources-finalizer.argocd.argoproj.io/foreground
 spec:
@@ -769,6 +773,8 @@ kind: Application
 metadata:
   name: pipelines
   namespace: mypattern-datacenter
+  labels:
+    validatedpatterns.io/pattern: mypattern
   finalizers:
   - resources-finalizer.argocd.argoproj.io/foreground
 spec:
@@ -815,6 +821,8 @@ kind: Application
 metadata:
   name: production-data-lake
   namespace: mypattern-datacenter
+  labels:
+    validatedpatterns.io/pattern: mypattern
   finalizers:
   - resources-finalizer.argocd.argoproj.io/foreground
 spec:
@@ -891,6 +899,8 @@ kind: Application
 metadata:
   name: external-secrets
   namespace: mypattern-datacenter
+  labels:
+    validatedpatterns.io/pattern: mypattern
   finalizers:
   - resources-finalizer.argocd.argoproj.io/foreground
 spec:
@@ -937,6 +947,8 @@ kind: Application
 metadata:
   name: golang-external-secrets
   namespace: mypattern-datacenter
+  labels:
+    validatedpatterns.io/pattern: mypattern
   finalizers:
   - resources-finalizer.argocd.argoproj.io/foreground
 spec:
@@ -983,6 +995,8 @@ kind: Application
 metadata:
   name: manuela-test
   namespace: mypattern-datacenter
+  labels:
+    validatedpatterns.io/pattern: mypattern
   finalizers:
   - resources-finalizer.argocd.argoproj.io/foreground
 spec:
@@ -1008,6 +1022,8 @@ kind: Application
 metadata:
   name: vault
   namespace: mypattern-datacenter
+  labels:
+    validatedpatterns.io/pattern: mypattern
   finalizers:
   - resources-finalizer.argocd.argoproj.io/foreground
 spec:

--- a/tests/clustergroup-medical-diagnosis-hub.expected.yaml
+++ b/tests/clustergroup-medical-diagnosis-hub.expected.yaml
@@ -613,6 +613,8 @@ kind: Application
 metadata:
   name: golang-external-secrets
   namespace: mypattern-hub
+  labels:
+    validatedpatterns.io/pattern: mypattern
   finalizers:
   - resources-finalizer.argocd.argoproj.io/foreground
 spec:
@@ -659,6 +661,8 @@ kind: Application
 metadata:
   name: kafdrop
   namespace: mypattern-hub
+  labels:
+    validatedpatterns.io/pattern: mypattern
   finalizers:
   - resources-finalizer.argocd.argoproj.io/foreground
 spec:
@@ -705,6 +709,8 @@ kind: Application
 metadata:
   name: kafka
   namespace: mypattern-hub
+  labels:
+    validatedpatterns.io/pattern: mypattern
   finalizers:
   - resources-finalizer.argocd.argoproj.io/foreground
 spec:
@@ -751,6 +757,8 @@ kind: Application
 metadata:
   name: odh
   namespace: mypattern-hub
+  labels:
+    validatedpatterns.io/pattern: mypattern
   finalizers:
   - resources-finalizer.argocd.argoproj.io/foreground
 spec:
@@ -797,6 +805,8 @@ kind: Application
 metadata:
   name: odf
   namespace: mypattern-hub
+  labels:
+    validatedpatterns.io/pattern: mypattern
   finalizers:
   - resources-finalizer.argocd.argoproj.io/foreground
 spec:
@@ -843,6 +853,8 @@ kind: Application
 metadata:
   name: serverless
   namespace: mypattern-hub
+  labels:
+    validatedpatterns.io/pattern: mypattern
   finalizers:
   - resources-finalizer.argocd.argoproj.io/foreground
 spec:
@@ -889,6 +901,8 @@ kind: Application
 metadata:
   name: xraylab-service-account
   namespace: mypattern-hub
+  labels:
+    validatedpatterns.io/pattern: mypattern
   finalizers:
   - resources-finalizer.argocd.argoproj.io/foreground
 spec:
@@ -935,6 +949,8 @@ kind: Application
 metadata:
   name: vault
   namespace: mypattern-hub
+  labels:
+    validatedpatterns.io/pattern: mypattern
   finalizers:
   - resources-finalizer.argocd.argoproj.io/foreground
 spec:
@@ -999,6 +1015,8 @@ kind: Application
 metadata:
   name: xraylab-database
   namespace: mypattern-hub
+  labels:
+    validatedpatterns.io/pattern: mypattern
   finalizers:
   - resources-finalizer.argocd.argoproj.io/foreground
 spec:
@@ -1045,6 +1063,8 @@ kind: Application
 metadata:
   name: xraylab-grafana-dashboards
   namespace: mypattern-hub
+  labels:
+    validatedpatterns.io/pattern: mypattern
   finalizers:
   - resources-finalizer.argocd.argoproj.io/foreground
 spec:
@@ -1091,6 +1111,8 @@ kind: Application
 metadata:
   name: xraylab-image-generator
   namespace: mypattern-hub
+  labels:
+    validatedpatterns.io/pattern: mypattern
   finalizers:
   - resources-finalizer.argocd.argoproj.io/foreground
 spec:
@@ -1146,6 +1168,8 @@ kind: Application
 metadata:
   name: xraylab-image-server
   namespace: mypattern-hub
+  labels:
+    validatedpatterns.io/pattern: mypattern
   finalizers:
   - resources-finalizer.argocd.argoproj.io/foreground
 spec:
@@ -1201,6 +1225,8 @@ kind: Application
 metadata:
   name: xraylab-init
   namespace: mypattern-hub
+  labels:
+    validatedpatterns.io/pattern: mypattern
   finalizers:
   - resources-finalizer.argocd.argoproj.io/foreground
 spec:

--- a/tests/clustergroup-normal.expected.yaml
+++ b/tests/clustergroup-normal.expected.yaml
@@ -523,6 +523,8 @@ kind: Application
 metadata:
   name: acm
   namespace: mypattern-example
+  labels:
+    validatedpatterns.io/pattern: mypattern
   finalizers:
   - resources-finalizer.argocd.argoproj.io/foreground
 spec:
@@ -578,6 +580,8 @@ kind: Application
 metadata:
   name: pipelines
   namespace: mypattern-example
+  labels:
+    validatedpatterns.io/pattern: mypattern
   finalizers:
   - resources-finalizer.argocd.argoproj.io/foreground
 spec:


### PR DESCRIPTION
feat:  Add labels to ArgoCD applications created by the VP framework.

PR relates to the work in [MBP-184] Operator: Update status section based on argo application state(s). This PR adds a label that the operator will query for all the applications that are part of a VP pattern. The operator will retrieve the applications and add the status information in the pattern CR. 

```
apiVersion: argoproj.io/v1alpha1
kind: Application
metadata:
  annotations:
  finalizers:
  - resources-finalizer.argocd.argoproj.io/foreground
  labels:
    app.kubernetes.io/instance: multicloud-gitops-hub
    validatedpatterns.io/pattern: multicloud-gitops
  name: acm
  namespace: multicloud-gitops-hub
spec:
  destination:
    name: in-cluster
    namespace: open-cluster-management
  ignoreDifferences:
...
  syncPolicy:
    automated: {}
    retry:
      limit: 20
```