### PR TITLE
Add support for ~/.config/validated-patterns/pattern-uuid

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,16 @@ TARGET_REPO=$(shell git ls-remote --get-url --symref $(TARGET_ORIGIN) | sed -e '
 # git branch --show-current is also available as of git 2.22, but we will use this for compatibility
 TARGET_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
 
+UUID_FILE ?= ~/.config/validated-patterns/pattern-uuid
+
 # --set values always take precedence over the contents of -f
-HELM_OPTS=-f values-global.yaml --set main.git.repoURL="$(TARGET_REPO)" --set main.git.revision=$(TARGET_BRANCH) $(TARGET_SITE_OPT) $(EXTRA_HELM_OPTS)
+ifneq ("$(wildcard $(UUID_FILE))","")
+	UUID := $(shell cat $(UUID_FILE))
+	HELM_OPTS=-f values-global.yaml --set main.git.repoURL="$(TARGET_REPO)" --set main.git.revision=$(TARGET_BRANCH) $(TARGET_SITE_OPT) --set main.analyticsUUID=$(UUID) $(EXTRA_HELM_OPTS)
+else
+	HELM_OPTS=-f values-global.yaml --set main.git.repoURL="$(TARGET_REPO)" --set main.git.revision=$(TARGET_BRANCH) $(TARGET_SITE_OPT) $(EXTRA_HELM_OPTS)
+endif
+
 
 ##@ Pattern Common Tasks
 

--- a/Makefile
+++ b/Makefile
@@ -20,14 +20,15 @@ TARGET_REPO=$(shell git ls-remote --get-url --symref $(TARGET_ORIGIN) | sed -e '
 TARGET_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
 
 UUID_FILE ?= ~/.config/validated-patterns/pattern-uuid
+UUID_HELM_OPTS ?=
 
 # --set values always take precedence over the contents of -f
 ifneq ("$(wildcard $(UUID_FILE))","")
 	UUID := $(shell cat $(UUID_FILE))
-	HELM_OPTS=-f values-global.yaml --set main.git.repoURL="$(TARGET_REPO)" --set main.git.revision=$(TARGET_BRANCH) $(TARGET_SITE_OPT) --set main.analyticsUUID=$(UUID) $(EXTRA_HELM_OPTS)
-else
-	HELM_OPTS=-f values-global.yaml --set main.git.repoURL="$(TARGET_REPO)" --set main.git.revision=$(TARGET_BRANCH) $(TARGET_SITE_OPT) $(EXTRA_HELM_OPTS)
+	UUID_HELM_OPTS := --set main.analyticsUUID=$(UUID)
 endif
+
+HELM_OPTS=-f values-global.yaml --set main.git.repoURL="$(TARGET_REPO)" --set main.git.revision=$(TARGET_BRANCH) $(TARGET_SITE_OPT) $(UUID_HELM_OPTS) $(EXTRA_HELM_OPTS)
 
 
 ##@ Pattern Common Tasks

--- a/README.md
+++ b/README.md
@@ -6,17 +6,17 @@
 
 This repository is never used as standalone. It is usually imported in each pattern as a subtree.
 In order to import the common/ the very first time you can use
-`https://github.com/hybrid-cloud-patterns/multicloud-gitops/blob/main/common/scripts/make_common_subtree.sh`
+`https://github.com/validatedpatterns/multicloud-gitops/blob/main/common/scripts/make_common_subtree.sh`
 
 In order to update your common subtree inside your pattern repository you can either use
-`https://github.com/hybrid-cloud-patterns/utilities/blob/main/scripts/update-common-everywhere.sh` or
+`https://github.com/validatedpatterns/utilities/blob/main/scripts/update-common-everywhere.sh` or
 do it manually by doing the following:
 
 ```sh
-git remote add -f upstream-common https://github.com/hybrid-cloud-patterns/common.git
+git remote add -f upstream-common https://github.com/validatedpatterns/common.git
 git merge -s subtree -Xtheirs -Xsubtree=common upstream-common/ha-vault
 ```
 
 ## Secrets
 
-There are two different secret formats parsed by the ansible bits. Both are documented [here](https://github.com/hybrid-cloud-patterns/common/tree/main/ansible/roles/vault_utils/README.md)
+There are two different secret formats parsed by the ansible bits. Both are documented [here](https://github.com/validatedpatterns/common/tree/main/ansible/roles/vault_utils/README.md)

--- a/ansible/roles/vault_utils/README.md
+++ b/ansible/roles/vault_utils/README.md
@@ -42,10 +42,16 @@ This relies on [kubernetes.core](https://docs.ansible.com/ansible/latest/collect
 
 ## Values secret file format
 
-Currently this role supports two formats: version 1.0 (which is the assumed default when not specified) and version 2.0.
-The latter is more fatureful and supports generating secrets directly into the vault and also prompting the user for a secret.
-By default, the first file that will looked up is `~/.config/hybrid-cloud-patterns/values-secret-<patternname>.yaml`, then
-`~/values-secret-<patternname>.yaml` and should that not exist it will look for `~/values-secret.yaml`.
+Currently this role supports two formats: version 1.0 (which is the assumed
+default when not specified) and version 2.0. The latter is more fatureful and
+supports generating secrets directly into the vault and also prompting the user
+for a secret.
+
+By default, the first file that will looked up is
+`~/.config/hybrid-cloud-patterns/values-secret-<patternname>.yaml`, then
+`~/.config/validated-patterns/values-secret-<patternname>.yaml`,
+`~/values-secret-<patternname>.yaml` and should that not exist it will look for
+`~/values-secret.yaml`.
 The paths can be overridden by setting the environment variable `VALUES_SECRET` to the path of the
 secret file.
 

--- a/ansible/roles/vault_utils/tasks/push_secrets.yaml
+++ b/ansible/roles/vault_utils/tasks/push_secrets.yaml
@@ -66,6 +66,7 @@
   vars:
     findme:
       - "~/.config/hybrid-cloud-patterns/values-secret-{{ pattern_name }}.yaml"
+      - "~/.config/validated-patterns/values-secret-{{ pattern_name }}.yaml"
       - "~/values-secret-{{ pattern_name }}.yaml"
       - "~/values-secret.yaml"
       - "{{ pattern_dir }}/values-secret.yaml.template"


### PR DESCRIPTION
* Pristine environment:
$ make show
helm template common/operator-install/ --name-template common -f values-global.yaml --set main.git.repoURL="https://github.com/hybrid-cloud-patterns/common.git" --set main.git.revision=vp-paths
---
apiVersion: gitops.hybrid-cloud-patterns.io/v1alpha1
kind: Pattern
metadata:
  name: common
  namespace: openshift-operators
spec:
  clusterGroupName: example
  gitSpec:
    targetRepo: https://github.com/hybrid-cloud-patterns/common.git
    targetRevision: vp-paths
  gitOpsSpec:
    operatorChannel: gitops-1.8
    operatorSource: redhat-operators
  multiSourceConfig:
    enabled: false
...

* Add UUID to the environment

$ echo "vp-team-bandini" >> ~/.config/validated-patterns/pattern-uuid
$ make show
helm template common/operator-install/ --name-template common -f values-global.yaml --set main.git.repoURL="https://github.com/hybrid-cloud-patterns/common.git" --set main.git.revision=vp-paths  --set main.analyticsUUID=vp-team-bandini
---
apiVersion: gitops.hybrid-cloud-patterns.io/v1alpha1
kind: Pattern
metadata:
  name: common
  namespace: openshift-operators
spec:
  clusterGroupName: example
  gitSpec:
    targetRepo: https://github.com/hybrid-cloud-patterns/common.git
    targetRevision: vp-paths
  gitOpsSpec:
    operatorChannel: gitops-1.8
    operatorSource: redhat-operators
  multiSourceConfig:
    enabled: false
  analyticsUUID: vp-team-bandini

...
