### PR TITLE
Rework installation target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,11 +47,9 @@ show: ## show the starting template without installing it
 .PHONY: operator-deploy
 operator-deploy operator-upgrade: validate-prereq validate-origin ## runs helm install
 	@set -e -o pipefail
-	# We reapply the CRD and if it already exists we do not error out
-	oc apply common/operator-install/crds/*.yaml 2>/dev/null || /bin/true
 	# Retry five times because the CRD might not be fully installed yet
 	for i in {1..5}; do \
-		helm template --name-template $(NAME) common/operator-install/ $(HELM_OPTS) | oc apply -f- && break || sleep 10; \
+		helm template --include-crds --name-template $(NAME) common/operator-install/ $(HELM_OPTS) | oc apply -f- && break || sleep 10; \
 	done
 
 .PHONY: uninstall


### PR DESCRIPTION
Drop the old logic and just install the CRD via OC and use helm template
for the rest.

The rationale is that helm install is very picky whenever it encounters
things that already exist. We have three potential scenarios at work
here:
A) User installs operator+pattern via CLI and updates the pattern via
   CLI (this worked before this change as well)
B) User installs operator+pattern via UI but runs updates (changing
   branch for example) via CLI (this worked before this change as well)
C) User installs only the operator via UI. Installs and updated the
   pattern via CLI. This was broken before this change. The error you'd
   get was:
   ```
   ./pattern.sh make install
   ...
   https://github.com/mbaldessari/multicloud-gitops.git - branch main: Running inside a container: Skipping git ssh checks
   + oc get crds patterns.gitops.hybrid-cloud-patterns.io
   + echo 'Reapplying helm chart:'
   Reapplying helm chart:
   + helm template --name-template multicloud-gitops common/operator-install/ -f values-global.yaml --set main.git.repoURL=https://github.com/mbaldessari/multicloud-gitops.git --set main.git.revision=main
   + oc apply set-last-applied --create-annotation -f-
   WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /home/michele/sno1-kubeconfig
   Error from server (NotFound): patterns.gitops.hybrid-cloud-patterns.io "multicloud-gitops" not found
   ```

With this change we simplify the process and we forcefully apply/install
the CRD for patterns via the oc command. And then we simply template out
the operator-install chart and oc apply it. We retry it a few times,
because the CRD might not yet be fully registered in the cluster.

Tested with on the A), B) and C) scenarios successfully.
