### PR TITLE
Allow imperative to be nil

### DIFF
--- a/clustergroup/templates/imperative/job.yaml
+++ b/clustergroup/templates/imperative/job.yaml
@@ -1,6 +1,6 @@
 {{- if not (eq .Values.enabled "plumbing") }}
 {{/* Define this if needed (jobs defined */}}
-{{- if (gt (len $.Values.clusterGroup.imperative.jobs) 0) -}}
+{{- if (and $.Values.clusterGroup.imperative (gt (len $.Values.clusterGroup.imperative.jobs) 0)) -}}
 ---
 apiVersion: batch/v1
 kind: CronJob


### PR DESCRIPTION
Tested by commenting out the whole `imperative` section in values-hub
and deploying MCG.
