### PR TITLE
Adding key to exclude target namespace in operatorgroup

### DIFF
--- a/clustergroup/templates/core/operatorgroup.yaml
+++ b/clustergroup/templates/core/operatorgroup.yaml
@@ -12,7 +12,7 @@ metadata:
   name: {{ $k }}-operator-group
   namespace: {{ $k }}
 spec:
-    {{- if not ( has $k $.Values.clusterGroup.operatorgroupExcludeTargetNS ) }}
+    {{- if not $v.excludeOperatorGroupTargetNS }}
   targetNamespaces:
   - {{ $k }}
     {{- end }}
@@ -24,10 +24,8 @@ metadata:
   name: {{ . }}-operator-group
   namespace: {{ . }}
 spec:
-    {{- if not ( has . $.Values.clusterGroup.operatorgroupExcludeTargetNS ) }}
   targetNamespaces:
   - {{ . }}
-    {{- end }}
   {{- end }} {{- /* if kindIs "string" $ns */}}
 ---
 {{- end }} {{- /* if or (empty $.Values.clusterGroup.operatorgroupExcludes) (not (has . $.Values.clusterGroup.operatorgroupExcludes)) */}}

--- a/clustergroup/templates/core/operatorgroup.yaml
+++ b/clustergroup/templates/core/operatorgroup.yaml
@@ -12,10 +12,14 @@ metadata:
   name: {{ $k }}-operator-group
   namespace: {{ $k }}
 spec:
-    {{- if not $v.excludeOperatorGroupTargetNS }}
   targetNamespaces:
+    {{- if $v.operatorgroup }}
+      {{- range $v.operatorgroup.targetNamespaces }}{{- /* We loop through the list of tergetnamespaces */}}
+  - {{ . }}
+      {{- end }}{{- /* End range targetNamespaces */}}
+    {{- else }}
   - {{ $k }}
-    {{- end }}
+    {{- end }}{{- /* End of if operatorGroup */}}
   {{- end }}{{- /* range $k, $v := $ns */}}
   {{- else if kindIs "string" $ns }}
 apiVersion: operators.coreos.com/v1

--- a/clustergroup/templates/core/operatorgroup.yaml
+++ b/clustergroup/templates/core/operatorgroup.yaml
@@ -15,7 +15,6 @@ spec:
   targetNamespaces:
   - {{ $k }}
   {{- end }}{{- /* range $k, $v := $ns */}}
-
   {{- else if kindIs "string" $ns }}
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
@@ -23,8 +22,10 @@ metadata:
   name: {{ . }}-operator-group
   namespace: {{ . }}
 spec:
+    {{- if not ( has . $.Values.clusterGroup.operatorgroupExcludeTargetNS ) }}
   targetNamespaces:
   - {{ . }}
+    {{- end }}
   {{- end }} {{- /* if kindIs "string" $ns */}}
 ---
 {{- end }} {{- /* if or (empty $.Values.clusterGroup.operatorgroupExcludes) (not (has . $.Values.clusterGroup.operatorgroupExcludes)) */}}

--- a/clustergroup/templates/core/operatorgroup.yaml
+++ b/clustergroup/templates/core/operatorgroup.yaml
@@ -12,8 +12,10 @@ metadata:
   name: {{ $k }}-operator-group
   namespace: {{ $k }}
 spec:
+    {{- if not ( has $k $.Values.clusterGroup.operatorgroupExcludeTargetNS ) }}
   targetNamespaces:
   - {{ $k }}
+    {{- end }}
   {{- end }}{{- /* range $k, $v := $ns */}}
   {{- else if kindIs "string" $ns }}
 apiVersion: operators.coreos.com/v1

--- a/clustergroup/templates/core/operatorgroup.yaml
+++ b/clustergroup/templates/core/operatorgroup.yaml
@@ -13,7 +13,7 @@ metadata:
   namespace: {{ $k }}
 spec:
   targetNamespaces:
-    {{- if or (and $v.operatorGroup (hasKey $v "targetNamespaces")) (and $v.operatorGroup (not (empty $v.targetNamespaces))) }}
+    {{- if (hasKey $v "targetNamespaces") }}
       {{- range $v.targetNamespaces }}{{- /* We loop through the list of tergetnamespaces */}}
   - {{ . }}
       {{- end }}{{- /* End range targetNamespaces */}}

--- a/clustergroup/templates/core/operatorgroup.yaml
+++ b/clustergroup/templates/core/operatorgroup.yaml
@@ -6,6 +6,7 @@
   {{- if kindIs "map" $ns }}
   {{- range $k, $v := $ns }}{{- /* We loop here even though the map has always just one key */}}
 
+{{- if $v.operatorGroup }}{{- /* Checks if the user sets operatorGroup: false */}}
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
@@ -13,14 +14,15 @@ metadata:
   namespace: {{ $k }}
 spec:
   targetNamespaces:
-    {{- if $v.operatorgroup }}
-      {{- range $v.operatorgroup.targetNamespaces }}{{- /* We loop through the list of tergetnamespaces */}}
+    {{- if and $v.operatorGroup (empty $v.targetNamespaces) }}
+      {{- range $v.targetNamespaces }}{{- /* We loop through the list of tergetnamespaces */}}
   - {{ . }}
       {{- end }}{{- /* End range targetNamespaces */}}
     {{- else }}
   - {{ $k }}
     {{- end }}{{- /* End of if operatorGroup */}}
   {{- end }}{{- /* range $k, $v := $ns */}}
+{{- end }}{{- /* End of if operatorGroup */}}
   {{- else if kindIs "string" $ns }}
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup

--- a/clustergroup/templates/core/operatorgroup.yaml
+++ b/clustergroup/templates/core/operatorgroup.yaml
@@ -5,8 +5,7 @@
 
   {{- if kindIs "map" $ns }}
   {{- range $k, $v := $ns }}{{- /* We loop here even though the map has always just one key */}}
-
-{{- if $v.operatorGroup }}{{- /* Checks if the user sets operatorGroup: false */}}
+  {{- if $v.operatorGroup }}{{- /* Checks if the user sets operatorGroup: false */}}
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
@@ -14,7 +13,7 @@ metadata:
   namespace: {{ $k }}
 spec:
   targetNamespaces:
-    {{- if and $v.operatorGroup (empty $v.targetNamespaces) }}
+    {{- if or (and $v.operatorGroup (hasKey $v "targetNamespaces")) (and $v.operatorGroup (not (empty $v.targetNamespaces))) }}
       {{- range $v.targetNamespaces }}{{- /* We loop through the list of tergetnamespaces */}}
   - {{ . }}
       {{- end }}{{- /* End range targetNamespaces */}}
@@ -22,7 +21,7 @@ spec:
   - {{ $k }}
     {{- end }}{{- /* End of if operatorGroup */}}
   {{- end }}{{- /* range $k, $v := $ns */}}
-{{- end }}{{- /* End of if operatorGroup */}}
+  {{- end }}{{- /* End of if operatorGroup */}}
   {{- else if kindIs "string" $ns }}
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup

--- a/clustergroup/values.schema.json
+++ b/clustergroup/values.schema.json
@@ -268,7 +268,7 @@
         },
         "operatorgroupExcludeTargetNS": {
           "type": "array",
-          "description": "List of namespaces to exclude the target namespace.",
+          "description": "Specify the list of namespaces where the target namespace field in the corresponding operatorgroup object should be excluded.",
           "items": {
             "type": "string"
           }

--- a/clustergroup/values.schema.json
+++ b/clustergroup/values.schema.json
@@ -266,6 +266,13 @@
             "type": "string"
           }
         },
+        "operatorgroupExcludeTargetNS": {
+          "type": "array",
+          "description": "List of namespaces to exclude the target namespace.",
+          "items": {
+            "type": "string"
+          }
+        },
         "hostedSite": {
           "type": "object",
           "items": {

--- a/examples/values-example.yaml
+++ b/examples/values-example.yaml
@@ -23,9 +23,14 @@ clusterGroup:
       annotations:
         openshift.io/cluster-monitoring: "true"
         owner: "namespace owner"
-      excludeOperatorGroupTargetNS: true
   - application-ci:
-      excludeOperatorGroupTargetNS: true
+      operatorgroup:
+        targetNamespaces:
+          - application-ci
+          - other-namespace
+  - exclude-targetns:
+      operatorgroup:
+        targetNamespaces:
   - include-ci
   - excludes-ci
 

--- a/examples/values-example.yaml
+++ b/examples/values-example.yaml
@@ -29,6 +29,8 @@ clusterGroup:
   operatorgroupExcludes:
   - excludes-ci
 
+  operatorgroupExcludeTargetNS:
+  - application-ci
 
   subscriptions:
     acm:

--- a/examples/values-example.yaml
+++ b/examples/values-example.yaml
@@ -35,6 +35,8 @@ clusterGroup:
   - exclude-og
   - totally-exclude-og:
       operatorGroup: false
+  - include-default-og:
+      operatorGroup: true
 
   operatorgroupExcludes:
   - exclude-og

--- a/examples/values-example.yaml
+++ b/examples/values-example.yaml
@@ -24,18 +24,20 @@ clusterGroup:
         openshift.io/cluster-monitoring: "true"
         owner: "namespace owner"
   - application-ci:
-      operatorgroup:
-        targetNamespaces:
-          - application-ci
-          - other-namespace
+      operatorGroup: true
+      targetNamespaces:
+        - application-ci
+        - other-namespace
   - exclude-targetns:
-      operatorgroup:
-        targetNamespaces:
+      operatorGroup: true
+      targetNamespaces:
   - include-ci
-  - excludes-ci
+  - exclude-og
+  - totally-exclude-og:
+      operatorGroup: false
 
   operatorgroupExcludes:
-  - excludes-ci
+  - exclude-og
 
   subscriptions:
     acm:

--- a/examples/values-example.yaml
+++ b/examples/values-example.yaml
@@ -23,14 +23,14 @@ clusterGroup:
       annotations:
         openshift.io/cluster-monitoring: "true"
         owner: "namespace owner"
-  - application-ci
+      excludeOperatorGroupTargetNS: true
+  - application-ci:
+      excludeOperatorGroupTargetNS: true
+  - include-ci
   - excludes-ci
 
   operatorgroupExcludes:
   - excludes-ci
-
-  operatorgroupExcludeTargetNS:
-  - application-ci
 
   subscriptions:
     acm:

--- a/tests/clustergroup-normal.expected.yaml
+++ b/tests/clustergroup-normal.expected.yaml
@@ -17,9 +17,18 @@ spec:
 apiVersion: v1
 kind: Namespace
 metadata:
+  name: application-ci
   labels:
     argocd.argoproj.io/managed-by: mypattern-example
-  name: application-ci
+spec:
+---
+# Source: clustergroup/templates/core/namespaces.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    argocd.argoproj.io/managed-by: mypattern-example
+  name: include-ci
 spec:
 ---
 # Source: clustergroup/templates/core/namespaces.yaml
@@ -168,13 +177,14 @@ data:
           annotations:
             openshift.io/cluster-monitoring: "true"
             owner: namespace owner
+          excludeOperatorGroupTargetNS: true
           labels:
             kubernetes.io/os: linux
             openshift.io/node-selector: ""
-      - application-ci
+      - application-ci:
+          excludeOperatorGroupTargetNS: true
+      - include-ci
       - excludes-ci
-      operatorgroupExcludeTargetNS:
-      - application-ci
       operatorgroupExcludes:
       - excludes-ci
       projects:
@@ -1043,8 +1053,6 @@ metadata:
   name: open-cluster-management-operator-group
   namespace: open-cluster-management
 spec:
-  targetNamespaces:
-  - open-cluster-management
 ---
 # Source: clustergroup/templates/core/operatorgroup.yaml
 apiVersion: operators.coreos.com/v1
@@ -1053,6 +1061,16 @@ metadata:
   name: application-ci-operator-group
   namespace: application-ci
 spec:
+---
+# Source: clustergroup/templates/core/operatorgroup.yaml
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: include-ci-operator-group
+  namespace: include-ci
+spec:
+  targetNamespaces:
+  - include-ci
 ---
 # Source: clustergroup/templates/core/subscriptions.yaml
 apiVersion: operators.coreos.com/v1alpha1

--- a/tests/clustergroup-normal.expected.yaml
+++ b/tests/clustergroup-normal.expected.yaml
@@ -46,7 +46,16 @@ kind: Namespace
 metadata:
   labels:
     argocd.argoproj.io/managed-by: mypattern-example
-  name: excludes-ci
+  name: exclude-og
+spec:
+---
+# Source: clustergroup/templates/core/namespaces.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: totally-exclude-og
+  labels:
+    argocd.argoproj.io/managed-by: mypattern-example
 spec:
 ---
 # Source: clustergroup/templates/imperative/namespace.yaml
@@ -190,17 +199,19 @@ data:
             kubernetes.io/os: linux
             openshift.io/node-selector: ""
       - application-ci:
-          operatorgroup:
-            targetNamespaces:
-            - application-ci
-            - other-namespace
+          operatorGroup: true
+          targetNamespaces:
+          - application-ci
+          - other-namespace
       - exclude-targetns:
-          operatorgroup:
-            targetNamespaces: null
+          operatorGroup: true
+          targetNamespaces: null
       - include-ci
-      - excludes-ci
+      - exclude-og
+      - totally-exclude-og:
+          operatorGroup: false
       operatorgroupExcludes:
-      - excludes-ci
+      - exclude-og
       projects:
       - datacenter
       sharedValueFiles:
@@ -504,6 +515,9 @@ spec:
             configMap:
               name: helm-values-configmap-example
           restartPolicy: Never
+---
+# Source: clustergroup/templates/core/operatorgroup.yaml
+---
 ---
 # Source: clustergroup/templates/core/subscriptions.yaml
 ---
@@ -1064,22 +1078,11 @@ spec:
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
-  name: open-cluster-management-operator-group
-  namespace: open-cluster-management
-spec:
-  targetNamespaces:
-  - open-cluster-management
----
-# Source: clustergroup/templates/core/operatorgroup.yaml
-apiVersion: operators.coreos.com/v1
-kind: OperatorGroup
-metadata:
   name: application-ci-operator-group
   namespace: application-ci
 spec:
   targetNamespaces:
   - application-ci
-  - other-namespace
 ---
 # Source: clustergroup/templates/core/operatorgroup.yaml
 apiVersion: operators.coreos.com/v1

--- a/tests/clustergroup-normal.expected.yaml
+++ b/tests/clustergroup-normal.expected.yaml
@@ -26,6 +26,15 @@ spec:
 apiVersion: v1
 kind: Namespace
 metadata:
+  name: exclude-targetns
+  labels:
+    argocd.argoproj.io/managed-by: mypattern-example
+spec:
+---
+# Source: clustergroup/templates/core/namespaces.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
   labels:
     argocd.argoproj.io/managed-by: mypattern-example
   name: include-ci
@@ -177,12 +186,17 @@ data:
           annotations:
             openshift.io/cluster-monitoring: "true"
             owner: namespace owner
-          excludeOperatorGroupTargetNS: true
           labels:
             kubernetes.io/os: linux
             openshift.io/node-selector: ""
       - application-ci:
-          excludeOperatorGroupTargetNS: true
+          operatorgroup:
+            targetNamespaces:
+            - application-ci
+            - other-namespace
+      - exclude-targetns:
+          operatorgroup:
+            targetNamespaces: null
       - include-ci
       - excludes-ci
       operatorgroupExcludes:
@@ -1053,6 +1067,8 @@ metadata:
   name: open-cluster-management-operator-group
   namespace: open-cluster-management
 spec:
+  targetNamespaces:
+  - open-cluster-management
 ---
 # Source: clustergroup/templates/core/operatorgroup.yaml
 apiVersion: operators.coreos.com/v1
@@ -1061,6 +1077,18 @@ metadata:
   name: application-ci-operator-group
   namespace: application-ci
 spec:
+  targetNamespaces:
+  - application-ci
+  - other-namespace
+---
+# Source: clustergroup/templates/core/operatorgroup.yaml
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: exclude-targetns-operator-group
+  namespace: exclude-targetns
+spec:
+  targetNamespaces:
 ---
 # Source: clustergroup/templates/core/operatorgroup.yaml
 apiVersion: operators.coreos.com/v1

--- a/tests/clustergroup-normal.expected.yaml
+++ b/tests/clustergroup-normal.expected.yaml
@@ -58,6 +58,15 @@ metadata:
     argocd.argoproj.io/managed-by: mypattern-example
 spec:
 ---
+# Source: clustergroup/templates/core/namespaces.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: include-default-og
+  labels:
+    argocd.argoproj.io/managed-by: mypattern-example
+spec:
+---
 # Source: clustergroup/templates/imperative/namespace.yaml
 apiVersion: v1
 kind: Namespace
@@ -210,6 +219,8 @@ data:
       - exclude-og
       - totally-exclude-og:
           operatorGroup: false
+      - include-default-og:
+          operatorGroup: true
       operatorgroupExcludes:
       - exclude-og
       projects:
@@ -515,9 +526,6 @@ spec:
             configMap:
               name: helm-values-configmap-example
           restartPolicy: Never
----
-# Source: clustergroup/templates/core/operatorgroup.yaml
----
 ---
 # Source: clustergroup/templates/core/subscriptions.yaml
 ---
@@ -1083,6 +1091,7 @@ metadata:
 spec:
   targetNamespaces:
   - application-ci
+  - other-namespace
 ---
 # Source: clustergroup/templates/core/operatorgroup.yaml
 apiVersion: operators.coreos.com/v1
@@ -1102,6 +1111,17 @@ metadata:
 spec:
   targetNamespaces:
   - include-ci
+---
+# Source: clustergroup/templates/core/operatorgroup.yaml
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: include-default-og-operator-group
+  namespace: include-default-og
+spec:
+  targetNamespaces:
+  - include-default-og
 ---
 # Source: clustergroup/templates/core/subscriptions.yaml
 apiVersion: operators.coreos.com/v1alpha1

--- a/tests/clustergroup-normal.expected.yaml
+++ b/tests/clustergroup-normal.expected.yaml
@@ -173,6 +173,8 @@ data:
             openshift.io/node-selector: ""
       - application-ci
       - excludes-ci
+      operatorgroupExcludeTargetNS:
+      - application-ci
       operatorgroupExcludes:
       - excludes-ci
       projects:
@@ -1051,8 +1053,6 @@ metadata:
   name: application-ci-operator-group
   namespace: application-ci
 spec:
-  targetNamespaces:
-  - application-ci
 ---
 # Source: clustergroup/templates/core/subscriptions.yaml
 apiVersion: operators.coreos.com/v1alpha1


### PR DESCRIPTION
Implements the issue describe in [Issue #296 ](https://github.com/validatedpatterns/common/issues/296)

- Added operatorgroupExcludeTargetNS key to exclude targetNamespace in an Operator Group
