### PR TITLE
Make .plugin handling consistent

### DIFF
--- a/clustergroup/templates/plumbing/applications.yaml
+++ b/clustergroup/templates/plumbing/applications.yaml
@@ -52,7 +52,7 @@ spec:
         path: {{ .path }}
         {{- end }}
         {{- if .plugin }}
-        plugin: {{ .plugin }}
+        plugin: {{ .plugin | toPrettyJson }}
         {{- end }}
         {{- if not .kustomize }}
         helm:


### PR DESCRIPTION
Add the toPrettyJson call where it is missing to ensure `plugin:` settings can be arbitrary objects and will be consistent. No tests or schemas need to change for this.