### PR TITLE
Preseed the patterns-operator-config configmap

### DIFF
--- a/operator-install/templates/pattern-operator-configmap.yaml
+++ b/operator-install/templates/pattern-operator-configmap.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: patterns-operator-config
+  namespace: openshift-operators
+data:
+  gitops.catalogSource: {{ .Values.main.gitops.operatorSource }}
+  gitops.channel: {{ .Values.main.gitops.channel }}
+
+  # gitops.sourceNamespace: GitOpsDefaultCatalogSourceNamespace
+  # gitops.installApprovalPlan: GitOpsDefaultApprovalPlan
+  # gitops.ManualSync: GitOpsDefaultManualSync
+  # gitops.name: GitOpsDefaultPackageName

--- a/tests/operator-install-industrial-edge-factory.expected.yaml
+++ b/tests/operator-install-industrial-edge-factory.expected.yaml
@@ -1,4 +1,19 @@
 ---
+# Source: pattern-install/templates/pattern-operator-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: patterns-operator-config
+  namespace: openshift-operators
+data:
+  gitops.catalogSource: redhat-operators
+  gitops.channel: gitops-1.8
+
+  # gitops.sourceNamespace: GitOpsDefaultCatalogSourceNamespace
+  # gitops.installApprovalPlan: GitOpsDefaultApprovalPlan
+  # gitops.ManualSync: GitOpsDefaultManualSync
+  # gitops.name: GitOpsDefaultPackageName
+---
 # Source: pattern-install/templates/pattern.yaml
 apiVersion: gitops.hybrid-cloud-patterns.io/v1alpha1
 kind: Pattern

--- a/tests/operator-install-industrial-edge-hub.expected.yaml
+++ b/tests/operator-install-industrial-edge-hub.expected.yaml
@@ -1,4 +1,19 @@
 ---
+# Source: pattern-install/templates/pattern-operator-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: patterns-operator-config
+  namespace: openshift-operators
+data:
+  gitops.catalogSource: redhat-operators
+  gitops.channel: gitops-1.8
+
+  # gitops.sourceNamespace: GitOpsDefaultCatalogSourceNamespace
+  # gitops.installApprovalPlan: GitOpsDefaultApprovalPlan
+  # gitops.ManualSync: GitOpsDefaultManualSync
+  # gitops.name: GitOpsDefaultPackageName
+---
 # Source: pattern-install/templates/pattern.yaml
 apiVersion: gitops.hybrid-cloud-patterns.io/v1alpha1
 kind: Pattern

--- a/tests/operator-install-medical-diagnosis-hub.expected.yaml
+++ b/tests/operator-install-medical-diagnosis-hub.expected.yaml
@@ -1,4 +1,19 @@
 ---
+# Source: pattern-install/templates/pattern-operator-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: patterns-operator-config
+  namespace: openshift-operators
+data:
+  gitops.catalogSource: redhat-operators
+  gitops.channel: gitops-1.8
+
+  # gitops.sourceNamespace: GitOpsDefaultCatalogSourceNamespace
+  # gitops.installApprovalPlan: GitOpsDefaultApprovalPlan
+  # gitops.ManualSync: GitOpsDefaultManualSync
+  # gitops.name: GitOpsDefaultPackageName
+---
 # Source: pattern-install/templates/pattern.yaml
 apiVersion: gitops.hybrid-cloud-patterns.io/v1alpha1
 kind: Pattern

--- a/tests/operator-install-naked.expected.yaml
+++ b/tests/operator-install-naked.expected.yaml
@@ -1,4 +1,19 @@
 ---
+# Source: pattern-install/templates/pattern-operator-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: patterns-operator-config
+  namespace: openshift-operators
+data:
+  gitops.catalogSource: redhat-operators
+  gitops.channel: gitops-1.8
+
+  # gitops.sourceNamespace: GitOpsDefaultCatalogSourceNamespace
+  # gitops.installApprovalPlan: GitOpsDefaultApprovalPlan
+  # gitops.ManualSync: GitOpsDefaultManualSync
+  # gitops.name: GitOpsDefaultPackageName
+---
 # Source: pattern-install/templates/pattern.yaml
 apiVersion: gitops.hybrid-cloud-patterns.io/v1alpha1
 kind: Pattern

--- a/tests/operator-install-normal.expected.yaml
+++ b/tests/operator-install-normal.expected.yaml
@@ -1,4 +1,19 @@
 ---
+# Source: pattern-install/templates/pattern-operator-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: patterns-operator-config
+  namespace: openshift-operators
+data:
+  gitops.catalogSource: redhat-operators
+  gitops.channel: gitops-1.8
+
+  # gitops.sourceNamespace: GitOpsDefaultCatalogSourceNamespace
+  # gitops.installApprovalPlan: GitOpsDefaultApprovalPlan
+  # gitops.ManualSync: GitOpsDefaultManualSync
+  # gitops.name: GitOpsDefaultPackageName
+---
 # Source: pattern-install/templates/pattern.yaml
 apiVersion: gitops.hybrid-cloud-patterns.io/v1alpha1
 kind: Pattern


### PR DESCRIPTION
This way we keep the main.gitops keys working which is needed for IIB
installs.

Tested with:
    export EXTRA_HELM_OPTS="--set main.gitops.channel=gitops-1.10"
   ./pattern.sh make install

and correctly got gitops from 1.10 installed.
