### PR TITLE
Fix: bug in task TASK [iib_ci : Mirror all the needed images]

### DIFF
--- a/ansible/roles/iib_ci/tasks/mirror-related-images.yml
+++ b/ansible/roles/iib_ci/tasks/mirror-related-images.yml
@@ -89,7 +89,7 @@
     image_urls: "{{ image_urls | default({}) | combine({item:
       {'mirrordest': mirror_dest + item | basename,
        'mirrordest_nosha': (mirror_dest + item | basename) | regex_replace('@.*$', ''),
-       'mirrordest_tag': iib}}, recursive=true) }}"
+       'mirrordest_tag': 'tag-' + item | basename | regex_replace('^.*@sha256:', '')}}, recursive=true) }}"
   loop: "{{ all_images }}"
   when: use_internal_registry
 

--- a/ansible/roles/iib_ci/templates/mirror.map.j2
+++ b/ansible/roles/iib_ci/templates/mirror.map.j2
@@ -1,11 +1,3 @@
-{% set previous_item = [] %}
-{% set tag_count = 1 %}
 {% for item in image_urls.values() %}
-{% if item.source_nosha in previous_item  %}
-    {{ item.source }}={{ item.mirrordest_nosha }}:{{ item.mirrordest_tag ~ '-' ~ tag_count }}
-    {% set tag_count = tag_count + 1 %}
-{% else %}
-    {{ item.source }}={{ item.mirrordest_nosha }}:{{ item.mirrordest_tag }}
-{% endif %}
-{% set previous_item = previous_item.append( item.source_nosha ) %}
+{{ item.source }}={{ item.mirrordest_nosha }}:{{ item.mirrordest_tag }}
 {% endfor %}

--- a/ansible/roles/iib_ci/templates/mirror.map.j2
+++ b/ansible/roles/iib_ci/templates/mirror.map.j2
@@ -1,3 +1,11 @@
+{% set previous_item = [] %}
+{% set tag_count = 1 %}
 {% for item in image_urls.values() %}
-{{ item.source }}={{ item.mirrordest_nosha }}:{{ item.mirrordest_tag }}
+{% if item.source_nosha in previous_item  %}
+    {{ item.source }}={{ item.mirrordest_nosha }}:{{ item.mirrordest_tag ~ '-' ~ tag_count }}
+    {% set tag_count = tag_count + 1 %}
+{% else %}
+    {{ item.source }}={{ item.mirrordest_nosha }}:{{ item.mirrordest_tag }}
+{% endif %}
+{% set previous_item = previous_item.append( item.source_nosha ) %}
 {% endfor %}


### PR DESCRIPTION
- Updated the Jinja2 template *ansible/roles/iib_ci/templates/mirror.map.j2* to add a '<iibnumber>-<count>' to the image tag if there's a source image that has the same name in the mirror.map file.

Example mirror.map entry:
registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:da5d5061dbc2ec5082cf14b6c600fb5400b83cf91d7ccebfa80680a238d275db=default-route-openshift-image-registry.apps.lc-claudiol-devsec-hub-535d-2.blueprints.rhecoeng.com/openshift-marketplace/ose-kube-rbac-proxy:610968
registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:d4de33150cb8c8faf0133b39553e6c972be5ace7ae787c98f3b77fca37748036=default-route-openshift-image-registry.apps.lc-claudiol-devsec-hub-535d-2.blueprints.rhecoeng.com/openshift-marketplace/ose-kube-rbac-proxy:610968

The above will generate an error in TASK [iib_ci : Mirror all the needed images]

2023-10-29 20:56:08,534 INFO     fatal: [localhost]: FAILED! => {"attempts": 5, "changed": true, "cmd": "set -o pipefail\noc image mirror -a \"/tmp/ansible.eunmaew5/.dockerconfigjson\" -f mirror.map --insecure --keep-manifest-list 2>&1 | tee -a image-mirror.log\n", "delta": "0:00:00.068476", "end": "2023-10-29 20:56:07.485885", "msg": "non-zero return code", "rc": 1, "start": "2023-10-29 20:56:07.417409", "stderr": "", "stderr_lines": [], "stdout": "error: file mirror.map, line 11: each destination tag may only be specified once: default-route-openshift-image-registry.apps.qe-mg-hub-aws-14022.aws.validatedpatterns.io/openshift-marketplace/ose-kube-rbac-proxy:610968", "stdout_lines": ["error: file mirror.map, line 11: each destination tag may only be specified once: default-route-openshift-image-registry.apps.qe-mg-hub-aws-14022.aws.validatedpatterns.io/openshift-marketplace/ose-kube-rbac-proxy:610968"]}
