### PR TITLE
Parametrize ESO caProvider fields

### DIFF
--- a/golang-external-secrets/templates/golang-external-secrets-hub-secretstore.yaml
+++ b/golang-external-secrets/templates/golang-external-secrets-hub-secretstore.yaml
@@ -10,19 +10,21 @@ spec:
       path: secret
       # Version of KV backend
       version: v2
+{{- if .Values.golangExternalSecrets.caProvider.enabled }}
 {{ if .Values.clusterGroup.isHubCluster }}
       caProvider:
-        type: ConfigMap
-        name: kube-root-ca.crt
-        key: ca.crt
-        namespace: golang-external-secrets
+        type: {{ .Values.golangExternalSecrets.caProvider.hubCluster.type }}
+        name: {{ .Values.golangExternalSecrets.caProvider.hubCluster.name }}
+        key: {{ .Values.golangExternalSecrets.caProvider.hubCluster.key }}
+        namespace: {{ .Values.golangExternalSecrets.caProvider.hubCluster.namespace }}
 {{ else }}
       caProvider:
-        type: Secret
-        name: hub-ca
-        key: hub-kube-root-ca.crt
-        namespace: imperative
+        type: {{ .Values.golangExternalSecrets.caProvider.nonhubCluster.type }}
+        name: {{ .Values.golangExternalSecrets.caProvider.nonhubCluster.name }}
+        key: {{ .Values.golangExternalSecrets.caProvider.nonhubCluster.key }}
+        namespace: {{ .Values.golangExternalSecrets.caProvider.nonhubCluster.namespace }}
 {{ end }}
+{{- end }}
       auth:
         kubernetes:
 {{ if .Values.clusterGroup.isHubCluster }}

--- a/golang-external-secrets/values.yaml
+++ b/golang-external-secrets/values.yaml
@@ -1,6 +1,22 @@
 ---
+# Eventually we should aim to move these two under the golangExternalSecrets key
 mountPath: "hub"
 mountRole: "hub-role"
+
+golangExternalSecrets:
+  # This controls how ESO connects to vault
+  caProvider:
+    enabled: true # If vault is exposed via a route that is signed by a non internal CA you might want to disable this
+    hubCluster:
+      type: ConfigMap
+      name: kube-root-ca.crt
+      key: ca.crt
+      namespace: golang-external-secrets
+    nonhubCluster:
+      type: Secret
+      name: hub-ca
+      key: hub-kube-root-ca.crt
+      namespace: imperative
 
 global:
   hubClusterDomain: hub.example.com


### PR DESCRIPTION
This will allow users to disable using the default kube-root-ca.crt
configmap and/or customize things fully.

So, for example, an environment which uses letsencrypt for the ingress
certs, but does not have that CA included in kube-root-ca.crt, can
simply override things with a /values-IBMCloud.yaml file with:

caProvider:
  enabled: false

Which will just use the CA System bundle to authenticate connections
from ESO to vault.
