### PR TITLE
Avoid nonhubCluster + hubCluster naming for ESO

### DIFF
--- a/golang-external-secrets/templates/golang-external-secrets-hub-secretstore.yaml
+++ b/golang-external-secrets/templates/golang-external-secrets-hub-secretstore.yaml
@@ -13,16 +13,16 @@ spec:
 {{- if .Values.golangExternalSecrets.caProvider.enabled }}
 {{ if .Values.clusterGroup.isHubCluster }}
       caProvider:
-        type: {{ .Values.golangExternalSecrets.caProvider.hubCluster.type }}
-        name: {{ .Values.golangExternalSecrets.caProvider.hubCluster.name }}
-        key: {{ .Values.golangExternalSecrets.caProvider.hubCluster.key }}
-        namespace: {{ .Values.golangExternalSecrets.caProvider.hubCluster.namespace }}
+        type: {{ .Values.golangExternalSecrets.caProvider.vaultHostCluster.type }}
+        name: {{ .Values.golangExternalSecrets.caProvider.vaultHostCluster.name }}
+        key: {{ .Values.golangExternalSecrets.caProvider.vaultHostCluster.key }}
+        namespace: {{ .Values.golangExternalSecrets.caProvider.vaultHostCluster.namespace }}
 {{ else }}
       caProvider:
-        type: {{ .Values.golangExternalSecrets.caProvider.nonhubCluster.type }}
-        name: {{ .Values.golangExternalSecrets.caProvider.nonhubCluster.name }}
-        key: {{ .Values.golangExternalSecrets.caProvider.nonhubCluster.key }}
-        namespace: {{ .Values.golangExternalSecrets.caProvider.nonhubCluster.namespace }}
+        type: {{ .Values.golangExternalSecrets.caProvider.vaultClientCluster.type }}
+        name: {{ .Values.golangExternalSecrets.caProvider.vaultClientCluster.name }}
+        key: {{ .Values.golangExternalSecrets.caProvider.vaultClientCluster.key }}
+        namespace: {{ .Values.golangExternalSecrets.caProvider.vaultClientCluster.namespace }}
 {{ end }}
 {{- end }}
       auth:

--- a/golang-external-secrets/values.yaml
+++ b/golang-external-secrets/values.yaml
@@ -7,12 +7,12 @@ golangExternalSecrets:
   # This controls how ESO connects to vault
   caProvider:
     enabled: true # If vault is exposed via a route that is signed by a non internal CA you might want to disable this
-    hubCluster:
+    vaultHostCluster:
       type: ConfigMap
       name: kube-root-ca.crt
       key: ca.crt
       namespace: golang-external-secrets
-    nonhubCluster:
+    vaultClientCluster:
       type: Secret
       name: hub-ca
       key: hub-kube-root-ca.crt


### PR DESCRIPTION
As mentioned in https://github.com/validatedpatterns/common/pull/391/files#r1391948610
prefer naming that is not related to to the "hub" concept, which
hopefuly will disappear one day in the future.
