### PR TITLE
Stop referencing remote actions via @main. Use a specific commit

### DIFF
--- a/acm/.github/workflows/update-helm-repo.yml
+++ b/acm/.github/workflows/update-helm-repo.yml
@@ -18,12 +18,12 @@ on:
 
 jobs:
   helmlint:
-    uses: validatedpatterns/helm-charts/.github/workflows/helmlint.yml@main
+    uses: validatedpatterns/helm-charts/.github/workflows/helmlint.yml@985ba37e0eb50b1b35ec194fc999eae2d0ae1486
     permissions:
       contents: read
 
   update-helm-repo:
     needs: [helmlint]
-    uses: validatedpatterns/helm-charts/.github/workflows/update-helm-repo.yml@main
+    uses: validatedpatterns/helm-charts/.github/workflows/update-helm-repo.yml@985ba37e0eb50b1b35ec194fc999eae2d0ae1486
     permissions: read-all
     secrets: inherit

--- a/clustergroup/.github/workflows/update-helm-repo.yml
+++ b/clustergroup/.github/workflows/update-helm-repo.yml
@@ -19,12 +19,12 @@ on:
 
 jobs:
   helmlint:
-    uses: validatedpatterns/helm-charts/.github/workflows/helmlint.yml@main
+    uses: validatedpatterns/helm-charts/.github/workflows/helmlint.yml@985ba37e0eb50b1b35ec194fc999eae2d0ae1486
     permissions:
       contents: read
 
   update-helm-repo:
     needs: [helmlint]
-    uses: validatedpatterns/helm-charts/.github/workflows/update-helm-repo.yml@main
+    uses: validatedpatterns/helm-charts/.github/workflows/update-helm-repo.yml@985ba37e0eb50b1b35ec194fc999eae2d0ae1486
     permissions: read-all
     secrets: inherit

--- a/golang-external-secrets/.github/workflows/update-helm-repo.yml
+++ b/golang-external-secrets/.github/workflows/update-helm-repo.yml
@@ -18,12 +18,12 @@ on:
 
 jobs:
   helmlint:
-    uses: validatedpatterns/helm-charts/.github/workflows/helmlint.yml@main
+    uses: validatedpatterns/helm-charts/.github/workflows/helmlint.yml@985ba37e0eb50b1b35ec194fc999eae2d0ae1486
     permissions:
       contents: read
 
   update-helm-repo:
     needs: [helmlint]
-    uses: validatedpatterns/helm-charts/.github/workflows/update-helm-repo.yml@main
+    uses: validatedpatterns/helm-charts/.github/workflows/update-helm-repo.yml@985ba37e0eb50b1b35ec194fc999eae2d0ae1486
     permissions: read-all
     secrets: inherit

--- a/hashicorp-vault/.github/workflows/update-helm-repo.yml
+++ b/hashicorp-vault/.github/workflows/update-helm-repo.yml
@@ -18,12 +18,12 @@ on:
 
 jobs:
   helmlint:
-    uses: validatedpatterns/helm-charts/.github/workflows/helmlint.yml@main
+    uses: validatedpatterns/helm-charts/.github/workflows/helmlint.yml@985ba37e0eb50b1b35ec194fc999eae2d0ae1486
     permissions:
       contents: read
 
   update-helm-repo:
     needs: [helmlint]
-    uses: validatedpatterns/helm-charts/.github/workflows/update-helm-repo.yml@main
+    uses: validatedpatterns/helm-charts/.github/workflows/update-helm-repo.yml@985ba37e0eb50b1b35ec194fc999eae2d0ae1486
     permissions: read-all
     secrets: inherit

--- a/letsencrypt/.github/workflows/update-helm-repo.yml
+++ b/letsencrypt/.github/workflows/update-helm-repo.yml
@@ -18,12 +18,12 @@ on:
 
 jobs:
   helmlint:
-    uses: validatedpatterns/helm-charts/.github/workflows/helmlint.yml@main
+    uses: validatedpatterns/helm-charts/.github/workflows/helmlint.yml@985ba37e0eb50b1b35ec194fc999eae2d0ae1486
     permissions:
       contents: read
 
   update-helm-repo:
     needs: [helmlint]
-    uses: validatedpatterns/helm-charts/.github/workflows/update-helm-repo.yml@main
+    uses: validatedpatterns/helm-charts/.github/workflows/update-helm-repo.yml@985ba37e0eb50b1b35ec194fc999eae2d0ae1486
     permissions: read-all
     secrets: inherit


### PR DESCRIPTION
Reason is that even though we've updated workflows in helm-chart, the
charts seem to still reference the an old commit:

validatedpatterns/helm-charts/.github/workflows/helmlint.yml@refs/tags/main (ee7ec78f30b8f72463633b781527dfa186d3e980)
