### PR TITLE
Check for rc attribute to exist

### DIFF
--- a/ansible/roles/vault_utils/tasks/push_secrets.yaml
+++ b/ansible/roles/vault_utils/tasks/push_secrets.yaml
@@ -30,7 +30,9 @@
     command:
       sh -c "vault list auth/{{ vault_hub }}/role | grep '{{ vault_hub }}-role'"
   register: vault_role_cmd
-  until: vault_role_cmd.rc == 0
+  until:
+    - vault_role_cmd.rc is defined
+    - vault_role_cmd.rc == 0
   retries: 20
   delay: 45
   changed_when: false


### PR DESCRIPTION
Sometimes CI would error out with:

    [localhost]: FAILED! => {"msg": "The conditional check
    'vault_role_cmd.rc == 0' failed. The error was: error while evaluating
    conditional (vault_role_cmd.rc == 0): 'dict object' has no attribute
    'rc'. 'dict object' has no attribute 'rc'"}

This can ahepn when a call returns error 500 for whatever reason.
Let's make sure we catch this situation and keep trying and don't give
up due to this spurious error.
