### PR TITLE
Switch imageDigestMirrors to AllowContactingSource

### DIFF
--- a/ansible/roles/iib_ci/templates/imageDigestMirror.yaml.j2
+++ b/ansible/roles/iib_ci/templates/imageDigestMirror.yaml.j2
@@ -10,9 +10,9 @@ spec:
     - mirrors:
         - {{ item.mirrordest_nosha }}
       source: {{ item.source_nosha }}
-      mirrorSourcePolicy: NeverContactSource
+      mirrorSourcePolicy: AllowContactingSource
     - mirrors:
         - {{ item.mirrordest_nosha }}
       source: {{ item.image_nosha }}
-      mirrorSourcePolicy: NeverContactSource
+      mirrorSourcePolicy: AllowContactingSource
 {% endfor %}


### PR DESCRIPTION
Currently when we load a preview operator via the IIB mechanism we
redirect all images making up the operator bundle to the
cluster-internal registry. This is all fine and well, except these
redirects (done via an ImageDigestMirrorSet) are based on image names
without any specific hashes. (This is because OCP won't allow
you to specify hashes).

The problem arises when there is a prerelease operator which includes an
image that is used by the other non-prerelease operators. So if AAP
prerelease uses the image "registry.redhat.io/public/redis-6" we
redirect all these redis 6 images towards the internal registry.

But if another operator needs the redis-6 image with a hash that is not
the exact same that is used by AAP prerelease, it will be unable to find
it on the internal registry because we never uploaded it.

This is an example error:
2023-12-13 07:18:06,216 INFO Warning Failed 64m (x6 over 66m) kubelet Error: ImagePullBackOff
2023-12-13 07:18:06,216 INFO Normal BackOff 83s (x286 over 66m) kubelet Back-off pulling image "registry.redhat.io/rhel8/redis-6@sha256:edbd40185ed8c20ee61ebdf9f2e1e1d7594598fceff963b4dee3201472d6deda"

And this is a relevant /etc/containers/registries.conf :
[[registry]]
prefix = ""
location = "registry.redhat.io/rhel8/redis-6"
blocked = true

[[registry.mirror]]
location = "default-route-openshift-image-registry.apps.mcg-hub.blueprints.rhecoeng.com/openshift-marketplace/redis-6"
insecure = true
pull-from-mirror = "digest-only"

If we change the `mirrorSourcePolicy` from `NeverContactSource` to
`AllowContactingSource` we actually avoid this problem entirely.
OCP will try to pull the images from both the internal registry and the
original source and use the one it was able to find.

Tested both on AAP and Gitops prerelease and both deployed correctly
which was not the case before.
