### PR TITLE
Add initial support for deploying private repos via CLI directly

### DIFF
--- a/operator-install/templates/pattern.yaml
+++ b/operator-install/templates/pattern.yaml
@@ -16,6 +16,10 @@ spec:
 {{- if .Values.main.analyticsUUID }}
   analyticsUUID: {{ .Values.main.analyticsUUID }}
 {{- end }} {{/* if .Values.main.analyticsUUID */}}
+{{- if and .Values.main.tokenSecret .Values.main.tokenSecretNamespace }}
+  tokenSecret: {{ .Values.main.tokenSecret }}
+  tokenSecretNamespace: {{ .Values.main.tokenSecretNamespace }}
+{{- end }} {{/* if and .Values.main.tokenSecret .Values.main.tokenSecretNamespace */}}
 {{- if .Values.main.extraParameters }}
   extraParameters:
 {{- range .Values.main.extraParameters }}

--- a/operator-install/values.yaml
+++ b/operator-install/values.yaml
@@ -18,3 +18,8 @@ main:
     source: community-operators
 
   clusterGroupName: default
+
+  # If you are using a private repository define the secret where
+  # credentials to access the private repository are
+  # tokenSecret:
+  # tokenSecretNamespace:


### PR DESCRIPTION
Tested with:

    export EXTRA_HELM_OPTS="--set main.tokenSecret=private-repo --set main.tokenSecretNamespace=openshift-operators"
    ./pattern.sh make install

Note that this is currently only working with https URLs because we have
logic in the Makefile to rewrite ssh-based git URLs into https ones.
