### PR TITLE
Account for podman versions older than 4.3.0

### DIFF
--- a/scripts/pattern-util.sh
+++ b/scripts/pattern-util.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
+
 function is_available {
   command -v $1 >/dev/null 2>&1 || { echo >&2 "$1 is required but it's not installed. Aborting."; exit 1; }
+}
+
+function version {
+    echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'
 }
 
 if [ -z "$PATTERN_UTILITY_CONTAINER" ]; then
@@ -11,14 +16,29 @@ readonly commands=(podman)
 for cmd in ${commands[@]}; do is_available "$cmd"; done
 
 UNSUPPORTED_PODMAN_VERSIONS="1.6 1.5"
+PODMAN_VERSION_STR=$(podman --version)
 for i in ${UNSUPPORTED_PODMAN_VERSIONS}; do
 	# We add a space
-	if podman --version | grep -q -E "\b${i}"; then
-		echo "Unsupported podman version. We recommend >= 4.2.0"
+	if echo "${PODMAN_VERSION_STR}" | grep -q -E "\b${i}"; then
+		echo "Unsupported podman version. We recommend > 4.3.0"
 		podman --version
 		exit 1
 	fi
 done
+
+# podman --version outputs:
+# podman version 4.8.2
+PODMAN_VERSION=$(echo "${PODMAN_VERSION_STR}" | awk '{ print $NF }')
+
+# podman < 4.3.0 do not support keep-id:uid=...
+if [ $(version "${PODMAN_VERSION}") -lt $(version "4.3.0") ]; then
+    PODMAN_ARGS="-v ${HOME}:/root"
+else
+    # We do not rely on bash's $UID and $GID because on MacOSX $GID is not set
+    MYUID=$(id -u)
+    MYGID=$(id -g)
+    PODMAN_ARGS="--user ${MYUID}:${MYGID} --userns keep-id:uid=${MYUID},gid=${MYGID}"
+fi
 
 if [ -n "$KUBECONFIG" ]; then
     if [[ ! "${KUBECONFIG}" =~ ^$HOME* ]]; then
@@ -31,17 +51,13 @@ fi
 # $HOME is mounted as itself for any files that are referenced with absolute paths
 # $HOME is mounted to /root because the UID in the container is 0 and that's where SSH looks for credentials
 
-# We do not rely on bash's $UID and $GID because on MacOSX $GID is not set
-MYUID=$(id -u)
-MYGID=$(id -g)
 podman run -it --rm --pull=newer \
 	--security-opt label=disable \
-	--user "${MYUID}:${MYGID}" \
-	--userns "keep-id:uid=${MYUID},gid=${MYGID}" \
 	-e EXTRA_HELM_OPTS \
 	-e KUBECONFIG \
 	-v "${HOME}":"${HOME}" \
 	-v "${HOME}":/pattern-home \
+	${PODMAN_ARGS} \
 	-w "$(pwd)" \
 	"$PATTERN_UTILITY_CONTAINER" \
 	$@


### PR DESCRIPTION
The addition of --userns keep-id:uid=...,gid=... is supported only on
podman versions >= 4.3.0 [1]

If we have an older version, let's just keep the same logic as before.

[1] https://github.com/containers/podman/blob/main/troubleshooting.md#39-podman-run-fails-with-error-unrecognized-namespace-mode-keep-iduid1000gid1000-passed
