### PR TITLE
Switch default gitops channel to gitops-1.11

### DIFF
--- a/operator-install/values.yaml
+++ b/operator-install/values.yaml
@@ -7,7 +7,7 @@ main:
     revision: main
 
   gitops:
-    channel: "gitops-1.8"
+    channel: "gitops-1.11"
     operatorSource: redhat-operators
 
   multiSourceConfig:

--- a/tests/operator-install-industrial-edge-factory.expected.yaml
+++ b/tests/operator-install-industrial-edge-factory.expected.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: openshift-operators
 data:
   gitops.catalogSource: redhat-operators
-  gitops.channel: gitops-1.8
+  gitops.channel: gitops-1.11
 
   # gitops.sourceNamespace: GitOpsDefaultCatalogSourceNamespace
   # gitops.installApprovalPlan: GitOpsDefaultApprovalPlan
@@ -26,7 +26,7 @@ spec:
     targetRepo: https://github.com/pattern-clone/mypattern
     targetRevision: main 
   gitOpsSpec:
-    operatorChannel: gitops-1.8
+    operatorChannel: gitops-1.11
     operatorSource: redhat-operators
   multiSourceConfig:
     enabled: false

--- a/tests/operator-install-industrial-edge-hub.expected.yaml
+++ b/tests/operator-install-industrial-edge-hub.expected.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: openshift-operators
 data:
   gitops.catalogSource: redhat-operators
-  gitops.channel: gitops-1.8
+  gitops.channel: gitops-1.11
 
   # gitops.sourceNamespace: GitOpsDefaultCatalogSourceNamespace
   # gitops.installApprovalPlan: GitOpsDefaultApprovalPlan
@@ -26,7 +26,7 @@ spec:
     targetRepo: https://github.com/pattern-clone/mypattern
     targetRevision: main 
   gitOpsSpec:
-    operatorChannel: gitops-1.8
+    operatorChannel: gitops-1.11
     operatorSource: redhat-operators
   multiSourceConfig:
     enabled: false

--- a/tests/operator-install-medical-diagnosis-hub.expected.yaml
+++ b/tests/operator-install-medical-diagnosis-hub.expected.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: openshift-operators
 data:
   gitops.catalogSource: redhat-operators
-  gitops.channel: gitops-1.8
+  gitops.channel: gitops-1.11
 
   # gitops.sourceNamespace: GitOpsDefaultCatalogSourceNamespace
   # gitops.installApprovalPlan: GitOpsDefaultApprovalPlan
@@ -26,7 +26,7 @@ spec:
     targetRepo: https://github.com/pattern-clone/mypattern
     targetRevision: main 
   gitOpsSpec:
-    operatorChannel: gitops-1.8
+    operatorChannel: gitops-1.11
     operatorSource: redhat-operators
   multiSourceConfig:
     enabled: false

--- a/tests/operator-install-naked.expected.yaml
+++ b/tests/operator-install-naked.expected.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: openshift-operators
 data:
   gitops.catalogSource: redhat-operators
-  gitops.channel: gitops-1.8
+  gitops.channel: gitops-1.11
 
   # gitops.sourceNamespace: GitOpsDefaultCatalogSourceNamespace
   # gitops.installApprovalPlan: GitOpsDefaultApprovalPlan
@@ -26,7 +26,7 @@ spec:
     targetRepo: https://github.com/pattern-clone/mypattern
     targetRevision: main 
   gitOpsSpec:
-    operatorChannel: gitops-1.8
+    operatorChannel: gitops-1.11
     operatorSource: redhat-operators
   multiSourceConfig:
     enabled: false

--- a/tests/operator-install-normal.expected.yaml
+++ b/tests/operator-install-normal.expected.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: openshift-operators
 data:
   gitops.catalogSource: redhat-operators
-  gitops.channel: gitops-1.8
+  gitops.channel: gitops-1.11
 
   # gitops.sourceNamespace: GitOpsDefaultCatalogSourceNamespace
   # gitops.installApprovalPlan: GitOpsDefaultApprovalPlan
@@ -26,7 +26,7 @@ spec:
     targetRepo: https://github.com/pattern-clone/mypattern
     targetRevision: main 
   gitOpsSpec:
-    operatorChannel: gitops-1.8
+    operatorChannel: gitops-1.11
     operatorSource: redhat-operators
   multiSourceConfig:
     enabled: false


### PR DESCRIPTION
Tested on both ocp 4.14 and 4.12.
4.12 is the oldest supported version at this point in time.
