### PR TITLE
Set the user's passwd entry inside the container

### DIFF
--- a/scripts/pattern-util.sh
+++ b/scripts/pattern-util.sh
@@ -35,9 +35,10 @@ if [ $(version "${PODMAN_VERSION}") -lt $(version "4.3.0") ]; then
     PODMAN_ARGS="-v ${HOME}:/root"
 else
     # We do not rely on bash's $UID and $GID because on MacOSX $GID is not set
+    MYNAME=$(id -n -u)
     MYUID=$(id -u)
     MYGID=$(id -g)
-    PODMAN_ARGS="--user ${MYUID}:${MYGID} --userns keep-id:uid=${MYUID},gid=${MYGID}"
+    PODMAN_ARGS="--passwd-entry ${MYNAME}:x:${MYUID}:${MYGID}:/pattern-home:/bin/bash --user ${MYUID}:${MYGID} --userns keep-id:uid=${MYUID},gid=${MYGID}"
 fi
 
 if [ -n "$KUBECONFIG" ]; then


### PR DESCRIPTION
The reason for this is somewhat multi-faceted, but boils down to the
fact that openssh does not consult the $HOME variable to find .ssh/*
files but only relies to the home folder entry in /etc/passwd.

So what might happen is the following scenario:
1. The remote is ssh based: `origin  git@github.com:validatedpatterns/industrial-edge`
2. The main Makefile invokes `git remote show origin` which triggers an ssh connection
3. The ssh connection fails because ssh ignores the $HOME variable and instead relies on the home in `getent passwd`. Which is set to:
   ```
   fedora:*:1000:1000:fedora Cloud User:/home/fedora/industrial-edge:/bin/sh
   ```
4. Newer podmans set the user's home folder automagically to the folder
   that is passed as current working directory (in our case we pass `-w
   $(pwd)`)

Under these circumstances ssh connection will fail because git+ssh will
look for ssh files in the current folder (aka entry in /etc/passwd):

        debug1: identity file /home/fedora/industrial-edge/.ssh/id_rsa type -1
        debug1: identity file /home/fedora/industrial-edge/.ssh/id_rsa-cert type -1

Fix this by making sure we force an /etc/passwd entry for the user
running podman that points to the $HOME directory (aka /pattern-home
inside the container).
