### PR TITLE
Upgrade helm to v3.13.2

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup helm
         uses: azure/setup-helm@v3
         with:
-          version: 'v3.12.3'
+          version: 'v3.13.2'
 
 
       ################################


### PR DESCRIPTION
This is the version we use in gitops-1.11 which is the new default
