### PR TITLE
Run validate-prereq only when not in a container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,15 +125,19 @@ validate-schema: ## validates values files against schema in common/clustergroup
 
 .PHONY: validate-prereq
 validate-prereq: ## verify pre-requisites
-	@echo "Checking prerequisites:"
-	@for t in $(EXECUTABLES); do if ! which $$t > /dev/null 2>&1; then echo "No $$t in PATH"; exit 1; fi; done
-	@echo "  Check for '$(EXECUTABLES)': OK"
-	@echo -n "  Check for python-kubernetes: "
-	@if ! ansible -m ansible.builtin.command -a "{{ ansible_python_interpreter }} -c 'import kubernetes'" localhost > /dev/null 2>&1; then echo "Not found"; exit 1; fi
-	@echo "OK"
-	@echo -n "  Check for kubernetes.core collection: "
-	@if ! ansible-galaxy collection list | grep kubernetes.core > /dev/null 2>&1; then echo "Not found"; exit 1; fi
-	@echo "OK"
+	@if [ ! -f /run/.containerenv ]; then\
+	  echo "Checking prerequisites:";\
+	  for t in $(EXECUTABLES); do if ! which $$t > /dev/null 2>&1; then echo "No $$t in PATH"; exit 1; fi; done;\
+	  echo "  Check for '$(EXECUTABLES)': OK";\
+	  echo -n "  Check for python-kubernetes: ";\
+	  if ! ansible -m ansible.builtin.command -a "{{ ansible_python_interpreter }} -c 'import kubernetes'" localhost > /dev/null 2>&1; then echo "Not found"; exit 1; fi;\
+	  echo "OK";\
+	  echo -n "  Check for kubernetes.core collection: ";\
+	  if ! ansible-galaxy collection list | grep kubernetes.core > /dev/null 2>&1; then echo "Not found"; exit 1; fi;\
+	  echo "OK";\
+	else\
+	  echo "Skipping prerequisites check as we're running inside a container";\
+	fi
 
 .PHONY: argo-healthcheck
 argo-healthcheck: ## Checks if all argo applications are synced


### PR DESCRIPTION
There is no point in testing the requirements when we use the container,
as we guarantee that those exist in there.

Tested as follows:

    ❯ make validate-prereq
    make -f common/Makefile validate-prereq
    make[1]: Entering directory '/home/michele/Engineering/cloud-patterns/multicloud-gitops'
    Checking prerequisites:
      Check for 'git helm oc ansible': OK
      Check for python-kubernetes: OK
      Check for kubernetes.core collection: OK
    make[1]: Leaving directory '/home/michele/Engineering/cloud-patterns/multicloud-gitops'
    ❯ ./pattern.sh make  validate-prereq
    make -f common/Makefile validate-prereq
    make[1]: Entering directory '/home/michele/Engineering/cloud-patterns/multicloud-gitops'
    Skipping prerequisites check as we're running inside a container
    make[1]: Leaving directory '/home/michele/Engineering/cloud-patterns/multicloud-gitops'
