### PR TITLE
Use gitops-1.11 in acm as well

### DIFF
--- a/acm/templates/policies/ocp-gitops-policy.yaml
+++ b/acm/templates/policies/ocp-gitops-policy.yaml
@@ -35,7 +35,7 @@ spec:
                   labels:
                     operators.coreos.com/openshift-gitops-operator.openshift-operators: ''
                 spec:
-                  channel: {{ default "gitops-1.8" .Values.main.gitops.channel }}
+                  channel: {{ default "gitops-1.11" .Values.main.gitops.channel }}
                   installPlanApproval: Automatic
                   name: openshift-gitops-operator
                   source: redhat-operators

--- a/acm/values.yaml
+++ b/acm/values.yaml
@@ -1,6 +1,6 @@
 main:
   gitops:
-    channel: "gitops-1.8"
+    channel: "gitops-1.11"
 
 global:
   extraValueFiles: []

--- a/tests/acm-industrial-edge-factory.expected.yaml
+++ b/tests/acm-industrial-edge-factory.expected.yaml
@@ -100,7 +100,7 @@ spec:
                   labels:
                     operators.coreos.com/openshift-gitops-operator.openshift-operators: ''
                 spec:
-                  channel: gitops-1.8
+                  channel: gitops-1.11
                   installPlanApproval: Automatic
                   name: openshift-gitops-operator
                   source: redhat-operators

--- a/tests/acm-industrial-edge-hub.expected.yaml
+++ b/tests/acm-industrial-edge-hub.expected.yaml
@@ -307,7 +307,7 @@ spec:
                   labels:
                     operators.coreos.com/openshift-gitops-operator.openshift-operators: ''
                 spec:
-                  channel: gitops-1.8
+                  channel: gitops-1.11
                   installPlanApproval: Automatic
                   name: openshift-gitops-operator
                   source: redhat-operators

--- a/tests/acm-medical-diagnosis-hub.expected.yaml
+++ b/tests/acm-medical-diagnosis-hub.expected.yaml
@@ -298,7 +298,7 @@ spec:
                   labels:
                     operators.coreos.com/openshift-gitops-operator.openshift-operators: ''
                 spec:
-                  channel: gitops-1.8
+                  channel: gitops-1.11
                   installPlanApproval: Automatic
                   name: openshift-gitops-operator
                   source: redhat-operators

--- a/tests/acm-naked.expected.yaml
+++ b/tests/acm-naked.expected.yaml
@@ -101,7 +101,7 @@ spec:
                   labels:
                     operators.coreos.com/openshift-gitops-operator.openshift-operators: ''
                 spec:
-                  channel: gitops-1.8
+                  channel: gitops-1.11
                   installPlanApproval: Automatic
                   name: openshift-gitops-operator
                   source: redhat-operators

--- a/tests/acm-normal.expected.yaml
+++ b/tests/acm-normal.expected.yaml
@@ -797,7 +797,7 @@ spec:
                   labels:
                     operators.coreos.com/openshift-gitops-operator.openshift-operators: ''
                 spec:
-                  channel: gitops-1.8
+                  channel: gitops-1.11
                   installPlanApproval: Automatic
                   name: openshift-gitops-operator
                   source: redhat-operators


### PR DESCRIPTION
This is mainly for consistency reasons as the value is taken from
main.gitops anyways.
