### PR TITLE
Small gitops channel cleanups

### DIFF
--- a/operator-install/templates/pattern.yaml
+++ b/operator-install/templates/pattern.yaml
@@ -13,7 +13,7 @@ spec:
     tokenSecretNamespace: {{ .Values.main.tokenSecretNamespace }}
 {{- end }} {{/* if and .Values.main.tokenSecret .Values.main.tokenSecretNamespace */}}
   gitOpsSpec:
-    operatorChannel: {{ default "gitops-1.8" .Values.main.gitops.channel }}
+    operatorChannel: {{ default "gitops-1.11" .Values.main.gitops.channel }}
     operatorSource: {{ default "redhat-operators" .Values.main.gitops.operatorSource }}
   multiSourceConfig:
     enabled: {{ .Values.main.multiSourceConfig.enabled }}

--- a/reference-output.yaml
+++ b/reference-output.yaml
@@ -112,7 +112,7 @@ metadata:
   labels:
     operators.coreos.com/openshift-gitops-operator.openshift-operators: ""
 spec:
-  channel: gitops-1.8
+  channel: gitops-1.11
   installPlanApproval: Automatic
   name: openshift-gitops-operator
   source: redhat-operators


### PR DESCRIPTION
Mainly for consistency reasons. gitops-1.11 is already the default
