### PR TITLE
Bind mount /etc/pki in the wrapper

### DIFF
--- a/scripts/pattern-util.sh
+++ b/scripts/pattern-util.sh
@@ -56,6 +56,7 @@ podman run -it --rm --pull=newer \
 	--security-opt label=disable \
 	-e EXTRA_HELM_OPTS \
 	-e KUBECONFIG \
+	-v /etc/pki:/etc/pki:ro \
 	-v "${HOME}":"${HOME}" \
 	-v "${HOME}":/pattern-home \
 	${PODMAN_ARGS} \


### PR DESCRIPTION
This is useful whenever a custom CA is installed on the system and is
needed to connect to a remote cluster.
