### PR TITLE
Properly error out in preview-all when we cannot connect to the cluster

### DIFF
--- a/scripts/preview-all.sh
+++ b/scripts/preview-all.sh
@@ -7,6 +7,14 @@ HUB=$( yq ".main.clusterGroupName" values-global.yaml )
 MANAGED_CLUSTERS=$( yq ".clusterGroup.managedClusterGroups.[].name" values-$HUB.yaml )
 ALL_CLUSTERS=( $HUB $MANAGED_CLUSTERS )
 
+CLUSTER_INFO_OUT=$(oc cluster-info 2>&1)
+CLUSTER_INFO_RET=$?
+if [ $CLUSTER_INFO_RET -ne 0 ]; then
+    echo "Could not access the cluster:"
+    echo "${CLUSTER_INFO_OUT}"
+    exit 1
+fi
+
 for cluster in ${ALL_CLUSTERS[@]}; do
     APPS=$( yq ".clusterGroup.applications.[].name" values-$cluster.yaml )
     for app in $APPS; do


### PR DESCRIPTION
Before:

    $ ./pattern.sh make preview-all
    make -f common/Makefile preview-all
    make[1]: Entering directory '/home/michele/Engineering/cloud-patterns/multicloud-gitops'
    error: Missing or incomplete configuration info.  Please point to an existing, complete config file:

      1. Via the command-line flag --kubeconfig
      2. Via the KUBECONFIG environment variable
      3. In your home directory as ~/.kube/config

    To view or setup config directly use the 'config' command.
    error: Missing or incomplete configuration info.  Please point to an existing, complete config file:

      1. Via the command-line flag --kubeconfig
      2. Via the KUBECONFIG environment variable
      3. In your home directory as ~/.kube/config

    To view or setup config directly use the 'config' command.

    ...This goes on for many more iterations...

After:

    $ ./pattern.sh make preview-all
    make -f common/Makefile preview-all
    make[1]: Entering directory '/home/michele/Engineering/cloud-patterns/multicloud-gitops'
    Could not access the cluster:
    error: Missing or incomplete configuration info.  Please point to an existing, complete config file:

      1. Via the command-line flag --kubeconfig
      2. Via the KUBECONFIG environment variable
      3. In your home directory as ~/.kube/config

    To view or setup config directly use the 'config' command.
    make[1]: *** [common/Makefile:59: preview-all] Error 1
    make[1]: Leaving directory '/home/michele/Engineering/cloud-patterns/multicloud-gitops'
    make: *** [Makefile:12: preview-all] Error 2
