### PR TITLE
Only include values files if they do exist in preview.sh

### DIFF
--- a/scripts/preview.sh
+++ b/scripts/preview.sh
@@ -62,16 +62,16 @@ OVERRIDES=$( getOverrides )
 VALUE_FILES=""
 IFS=$'\n'
 for line in $sharedValueFiles; do
-    if [ $line != "null" ]; then
-	file=$(replaceGlobals $line)
-	VALUE_FILES="$VALUE_FILES -f $PWD$file"
+    if [ $line != "null" ] && [ -f $line ]; then
+	    file=$(replaceGlobals $line)
+	    VALUE_FILES="$VALUE_FILES -f $PWD$file"
     fi
 done
 
 for line in $appValueFiles; do
-    if [ $line != "null" ]; then
-	file=$(replaceGlobals $line)
-	VALUE_FILES="$VALUE_FILES -f $PWD$file"
+    if [ $line != "null" ] && [ -f $line ]; then
+	    file=$(replaceGlobals $line)
+	    VALUE_FILES="$VALUE_FILES -f $PWD$file"
     fi
 done
 


### PR DESCRIPTION
This is because in helm we use "ignoreMissingValueFiles: true". I.e. we
just ignore non existing value files. Let's do the same for the
preview.sh script.

Before:

    ❯ make preview-all
    make -f common/Makefile preview-all
    make[1]: Entering directory '/home/michele/Engineering/cloud-patterns/multicloud-gitops'
    Error: open /home/michele/Engineering/cloud-patterns/multicloud-gitops/overrides/values-None.yaml: no such file or directory
    Error: open /home/michele/Engineering/cloud-patterns/multicloud-gitops/overrides/values-None.yaml: no such file or directory
    Error: open /home/michele/Engineering/cloud-patterns/multicloud-gitops/overrides/values-None.yaml: no such file or directory
    Error: open /home/michele/Engineering/cloud-patterns/multicloud-gitops/overrides/values-None.yaml: no such file or directory
    Error: open /home/michele/Engineering/cloud-patterns/multicloud-gitops/overrides/values-None.yaml: no such file or directory
    common/scripts/preview.sh: eval: line 79: unexpected EOF while looking for matching `"'
    common/scripts/preview.sh: eval: line 79: unexpected EOF while looking for matching `"'
    common/scripts/preview.sh: eval: line 79: unexpected EOF while looking for matching `"'
    make[1]: *** [common/Makefile:59: preview-all] Error 2
    make[1]: Leaving directory '/home/michele/Engineering/cloud-patterns/multicloud-gitops'
    make: *** [Makefile:12: preview-all] Error 2

After:

    ❯ make preview-all > /dev/null ; echo $?
    0
