### PR TITLE
Do not error out in preview when kustomize: true

### DIFF
--- a/scripts/preview-all.sh
+++ b/scripts/preview-all.sh
@@ -18,6 +18,7 @@ fi
 for cluster in ${ALL_CLUSTERS[@]}; do
     APPS=$( yq ".clusterGroup.applications.[].name" values-$cluster.yaml )
     for app in $APPS; do
+        printf "# Parsing application $app from cluster $cluster\n"
         common/scripts/preview.sh $cluster $app $REPO $TARGET_BRANCH
     done
 done

--- a/scripts/preview.sh
+++ b/scripts/preview.sh
@@ -78,7 +78,7 @@ done
 
 if [ $isKustomize == "true" ]; then
     kustomizePath=$(yq ".clusterGroup.applications.$APP.path" values-$SITE.yaml)
-    cmd="kustomize build ${kustomizePath}"
+    cmd="oc kustomize ${kustomizePath}"
     eval "$cmd"
 else
     cmd="helm template $chart --name-template ${APP} -n ${namespace} ${VALUE_FILES} ${OVERRIDES} ${CLUSTER_OPTS}"

--- a/scripts/preview.sh
+++ b/scripts/preview.sh
@@ -57,6 +57,7 @@ CLUSTER_OPTS="$CLUSTER_OPTS --set global.clusterPlatform=$platform"
 
 sharedValueFiles=$(yq ".clusterGroup.sharedValueFiles" values-$SITE.yaml)
 appValueFiles=$(yq ".clusterGroup.applications.$APP.extraValueFiles" values-$SITE.yaml)
+isKustomize=$(yq ".clusterGroup.applications.$APP.kustomize" values-$SITE.yaml)
 OVERRIDES=$( getOverrides )
 
 VALUE_FILES=""
@@ -75,5 +76,11 @@ for line in $appValueFiles; do
     fi
 done
 
-cmd="helm template $chart --name-template ${APP} -n ${namespace} ${VALUE_FILES} ${OVERRIDES} ${CLUSTER_OPTS}"
-eval "$cmd"
+if [ $isKustomize == "true" ]; then
+    kustomizePath=$(yq ".clusterGroup.applications.$APP.path" values-$SITE.yaml)
+    cmd="kustomize build ${kustomizePath}"
+    eval "$cmd"
+else
+    cmd="helm template $chart --name-template ${APP} -n ${namespace} ${VALUE_FILES} ${OVERRIDES} ${CLUSTER_OPTS}"
+    eval "$cmd"
+fi


### PR DESCRIPTION
When `kustomize: true` simply take the path and call `kustomize build
<path>`. In any other case keep using helm for templating.

Before:
    ...
    + common/scripts/preview.sh hub compliance-operator https://github.com/mbaldessari/multicloud-gitops.git preview-fixes
    Error: Chart.yaml file is missing

After:
    ...
    + common/scripts/preview.sh hub compliance-operator https://github.com/mbaldessari/multicloud-gitops.git preview-fixes
    apiVersion: console.openshift.io/v1
    kind: ConsoleNotification
    metadata:
      name: purpose-banner
    spec:
      backgroundColor: '#ff0000'
      color: '#fff'
      location: BannerTop
      text: HUBOPS
