### PR TITLE
Add .global.secretStore.backend in the clustergroup schema

### DIFF
--- a/clustergroup/templates/imperative/unsealjob.yaml
+++ b/clustergroup/templates/imperative/unsealjob.yaml
@@ -1,4 +1,6 @@
-{{- if eq .Values.global.secretStore.backend "vault" | default "vault" }}
+{{/* If the backend is not set at all we default to "vault". See https://www.github.com/helm/helm/issues/3308
+     why we avoid using the default function */}}
+{{- if or (eq .Values.global.secretStore.backend "vault") (not (hasKey .Values.global.secretStore "backend")) }}
 {{- if not (eq .Values.enabled "plumbing") }}
 {{- if $.Values.clusterGroup.isHubCluster }}
 ---

--- a/clustergroup/values.schema.json
+++ b/clustergroup/values.schema.json
@@ -153,12 +153,27 @@
         },
         "options": {
           "$ref": "#/definitions/Options"
+        },
+        "secretStore": {
+          "$ref": "#/definitions/GlobalSecretStore"
         }
       },
       "required": [
         "options"
       ],
       "title": "Global"
+    },
+    "GlobalSecretStore": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "backend": {
+          "type": "string",
+          "description": "Name of the secrets backend",
+          "default": "vault"
+        }
+      },
+      "title": "GlobalSecretsStore"
     },
     "GlobalGit": {
       "type": "object",

--- a/golang-external-secrets/templates/kubernetes/golang-external-secrets-hub-secretstore.yaml
+++ b/golang-external-secrets/templates/kubernetes/golang-external-secrets-hub-secretstore.yaml
@@ -1,10 +1,9 @@
-{{- $backend := .Values.global.secretStore.backend | default "vault" }}
-{{- if eq $backend "kubernetes" }}
+{{- if eq .Values.global.secretStore.backend "kubernetes" }}
 ---
 apiVersion: external-secrets.io/v1beta1
 kind: ClusterSecretStore
 metadata:
-  name: {{ $backend }}-backend
+  name: kubernetes-backend
   namespace: golang-external-secrets
 spec:
   provider:

--- a/golang-external-secrets/templates/vault/golang-external-secrets-hub-secretstore.yaml
+++ b/golang-external-secrets/templates/vault/golang-external-secrets-hub-secretstore.yaml
@@ -1,10 +1,9 @@
-{{- $backend := .Values.global.secretStore.backend | default "vault" }}
-{{- if eq $backend "vault" }}
+{{- if or (eq .Values.global.secretStore.backend "vault") (not (hasKey .Values.global.secretStore "backend")) }}
 ---
 apiVersion: external-secrets.io/v1beta1
 kind: ClusterSecretStore
 metadata:
-  name: {{ $backend }}-backend
+  name: vault-backend
   namespace: golang-external-secrets
 spec:
   provider:


### PR DESCRIPTION
It is currently not there even though we mention it in the values files.
