### PR TITLE
Force strings in extraParametersNested

### DIFF
--- a/clustergroup/templates/plumbing/applications.yaml
+++ b/clustergroup/templates/plumbing/applications.yaml
@@ -105,7 +105,7 @@ spec:
         {{- end }}
         {{- range $k, $v := $.Values.extraParametersNested }}
             - name: {{ $k }}
-              value: {{ $v }}
+              value: {{ printf "%s" $v | quote }}
         {{- end }}
         {{- range .overrides }}
             - name: {{ .name  }}
@@ -184,7 +184,7 @@ spec:
           {{- end }}
           {{- range $k, $v := $.Values.extraParametersNested }}
           - name: {{ $k }}
-            value: {{ $v }}
+            value: {{ printf "%s" $v | quote }}
           {{- end }}
           {{- range .overrides }}
           - name: {{ .name }}
@@ -251,7 +251,7 @@ spec:
         {{- end }}
         {{- range $k, $v := $.Values.extraParametersNested }}
         - name: {{ $k }}
-          value: {{ $v }}
+          value: {{ printf "%s" $v | quote }}
         {{- end }}
         {{- range .overrides }}
         - name: {{ .name }}


### PR DESCRIPTION
Otherwise if we pass a boolean in the extraParametersNested we will get:

  spec.source.helm.parameters[10].value: Invalid value: "boolean":
    spec.source.helm.parameters[10].value in body must be of type string:
    "boolean"
