### PR TITLE
feat: Support for issue #459

### DIFF
--- a/clustergroup/templates/_helpers.tpl
+++ b/clustergroup/templates/_helpers.tpl
@@ -70,3 +70,155 @@ Default always defined valueFiles to be included in Applications but with a pref
 {{- end }} {{/* range $.Values.global.extraValueFiles */}}
 {{- end }} {{/* if $.Values.global.extraValueFiles */}}
 {{- end }} {{/* clustergroup.app.globalvalues.prefixedvaluefiles */}}
+
+{{/* 
+Helper function to generate AppProject from a map object
+Called from common/clustergroup/templates/plumbing/projects.yaml 
+*/}}
+{{- define "clustergroup.template.plumbing.projects.map" -}}
+{{- $projects := index . 0 }}
+{{- $namespace := index . 1 }}
+{{- $enabled := index . 2 }}
+{{- range $k, $v := $projects}}
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: {{ $k }}
+{{- if (eq $enabled "plumbing") }}
+  namespace: openshift-gitops
+{{- else }}
+  namespace: {{ $namespace }}
+{{- end }}
+spec:
+  description: "Pattern {{ . }}"
+  destinations:
+  - namespace: '*'
+    server: '*'
+  clusterResourceWhitelist:
+  - group: '*'
+    kind: '*'
+  namespaceResourceWhitelist:
+  - group: '*'
+    kind: '*'
+  sourceRepos:
+  - '*'
+status: {}
+---
+{{- end }}
+{{- end }}
+
+{{/* 
+  Helper function to generate AppProject from a list object.
+  Called from common/clustergroup/templates/plumbing/projects.yaml 
+*/}}
+{{- define "clustergroup.template.plumbing.projects.list" -}}
+{{- $projects := index . 0 }}
+{{- $namespace := index . 1 }}
+{{- $enabled := index . 2 }}
+{{- range $projects}}
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: {{ . }}
+{{- if (eq $enabled "plumbing") }}
+  namespace: openshift-gitops
+{{- else }}
+  namespace: {{ $namespace }}
+{{- end }}
+spec:
+  description: "Pattern {{ . }}"
+  destinations:
+  - namespace: '*'
+    server: '*'
+  clusterResourceWhitelist:
+  - group: '*'
+    kind: '*'
+  namespaceResourceWhitelist:
+  - group: '*'
+    kind: '*'
+  sourceRepos:
+  - '*'
+status: {}
+{{- end }}
+{{- end }}
+
+{{/* 
+  Helper function to generate Namespaces from a map object.
+  Arguments passed as a list object are:
+  0 - The namespace hash keys
+  1 - Pattern name from .Values.global.pattern
+  2 - Cluster group name from .Values.clusterGroup.name
+  Called from common/clustergroup/templates/core/namespaces.yaml 
+*/}}
+{{- define "clustergroup.template.core.namespaces.map" -}}
+{{- $ns := index . 0 }}
+{{- $patternName := index . 1 }}
+{{- $clusterGroupName := index . 2 }}
+
+{{- range $k, $v := $ns }}{{- /* We loop here even though the map has always just one key */}}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ $k }}
+  {{- if ne $v nil }}
+  labels:
+    argocd.argoproj.io/managed-by: {{ $patternName }}-{{ .clusterGroupName }}
+    {{- if $v.labels }}
+    {{- range $key, $value := $v.labels }} {{- /* We loop here even though the map has always just one key */}}
+    {{ $key }}: {{ $value | default "" | quote }}
+    {{- end }}
+    {{- end }}
+  {{- if $v.annotations }}
+  annotations:
+    {{- range $key, $value := $v.annotations }} {{- /* We loop through the map to get key/value pairs */}}
+    {{ $key }}: {{ $value | default "" | quote }}
+    {{- end }}
+  {{- end }}{{- /* if $v.annotations */}}
+  {{- end }}
+spec:
+---
+{{- end }}{{- /* range $k, $v := $ns */}}
+{{- end }}
+
+{{- /* 
+  Helper function to generate OperatorGroup from a map object.
+  Arguments passed as a list object are:
+  0 - The namespace hash keys
+  1 - The operatorExcludes section from .Values.clusterGroup.operatorgroupExcludes
+  Called from common/clustergroup/templates/core/operatorgroup.yaml
+*/ -}}
+{{- define "clustergroup.template.core.operatorgroup.map" -}}
+{{- $ns := index . 0 }}
+{{- $operatorgroupExcludes := index . 1 }}
+{{- if or (empty $operatorgroupExcludes) (not (has . $operatorgroupExcludes)) }}
+  {{- range $k, $v := $ns }}{{- /* We loop here even though the map has always just one key */}}
+  {{- if $v }}
+    {{- if $v.operatorGroup }}{{- /* Checks if the user sets operatorGroup: false */}}
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: {{ $k }}-operator-group
+  namespace: {{ $k }}
+spec:
+  targetNamespaces:
+      {{- if (hasKey $v "targetNamespaces") }}
+        {{- range $v.targetNamespaces }}{{- /* We loop through the list of tergetnamespaces */}}
+  - {{ . }}
+        {{- end }}{{- /* End range targetNamespaces */}}
+      {{- else }}
+  - {{ $k }}
+      {{- end }}{{- /* End of if hasKey $v "targetNamespaces" */}}
+    {{- end }}{{- /* End if $v.operatorGroup */}}
+  {{- else }}{{- /* else if $v == nil  */}}
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: {{ $k }}-operator-group
+  namespace: {{ $k }}
+spec:
+  targetNamespaces:
+  - {{ $k }}
+  {{- end }}{{- /* end if $v */}}
+  {{- end }}{{- /* End range $k, $v = $ns */}}
+{{- end }}{{- /* End of if operatorGroupExcludes */}}
+{{- end }} {{- /* End define  "clustergroup.template.core.operatorgroup.map" */}}

--- a/clustergroup/templates/core/namespaces.yaml
+++ b/clustergroup/templates/core/namespaces.yaml
@@ -1,4 +1,13 @@
 {{- if not (eq .Values.enabled "plumbing") }}
+{{- /*
+  We first check if namespaces are defined as a map.  If it is we call
+  our helper function in _helpers.tpl to process the namespaces
+  described in the values file. This is to support issue 
+  https://github.com/validatedpatterns/common/issues/459 created by our customer.
+*/ -}}
+{{- if kindIs "map" .Values.clusterGroup.namespaces }}
+{{- template "clustergroup.template.core.namespaces.map" (list .Values.clusterGroup.namespaces $.Values.global.pattern $.Values.clusterGroup.name) }}
+{{- else }}
 {{- range $ns := .Values.clusterGroup.namespaces }}
 apiVersion: v1
 kind: Namespace
@@ -28,5 +37,6 @@ metadata:
   {{- end }} {{- /* if kindIs "string" $ns */}}
 spec:
 ---
+{{- end }}
 {{- end }}
 {{- end }}

--- a/clustergroup/templates/core/operatorgroup.yaml
+++ b/clustergroup/templates/core/operatorgroup.yaml
@@ -1,4 +1,13 @@
 {{- if not (eq .Values.enabled "plumbing") }}
+{{- /*
+  We first check if namespaces are defined as a map.  If it is we call
+  our helper function in _helpers.tpl to process the projects
+  described in the values file. This is to support issue 
+  https://github.com/validatedpatterns/common/issues/459 created by our customer.
+*/ -}}
+{{- if kindIs "map" .Values.clusterGroup.namespaces }}
+{{- template "clustergroup.template.core.operatorgroup.map" (list .Values.clusterGroup.namespaces .Values.clusterGroup.operatorgroupExcludes) }}
+{{- else }}
 {{- range $ns := .Values.clusterGroup.namespaces }}
 
 {{- if or (empty $.Values.clusterGroup.operatorgroupExcludes) (not (has . $.Values.clusterGroup.operatorgroupExcludes)) }}
@@ -35,4 +44,5 @@ spec:
 ---
 {{- end }} {{- /* if or (empty $.Values.clusterGroup.operatorgroupExcludes) (not (has . $.Values.clusterGroup.operatorgroupExcludes)) */}}
 {{- end }} {{- /* range $ns := .Values.clusterGroup.namespaces */}}
+{{- end }} {{- /* if kindIs "map" $ns */}}
 {{- end }} {{- /* if not (eq .Values.enabled "plumbing") */}}

--- a/clustergroup/templates/plumbing/projects.yaml
+++ b/clustergroup/templates/plumbing/projects.yaml
@@ -1,5 +1,14 @@
 {{- if not (eq .Values.enabled "core") }}
 {{- $namespace := print $.Values.global.pattern "-" $.Values.clusterGroup.name }}
+{{- /*
+  We first check if projects are defined as a map.  If it is we call
+  our helper function in _helpers.tpl to process the projects
+  described in the values file. This is to support issue 
+  https://github.com/validatedpatterns/common/issues/459 created by our customer.
+*/ -}}
+{{- if kindIs "map" .Values.clusterGroup.projects }}
+{{- template "clustergroup.template.plumbing.projects.map" (list .Values.clusterGroup.projects $namespace $.Values.enabled) }}  
+{{- else }}
 {{- range .Values.clusterGroup.projects }}
 apiVersion: argoproj.io/v1alpha1
 kind: AppProject
@@ -25,5 +34,6 @@ spec:
   - '*'
 status: {}
 ---
-{{- end }}
-{{- end }}
+{{- end }} {{- /* end range */ -}}
+{{- end }} {{- /* end if map */ -}}
+{{- end }} {{- /* end if not "core" */ -}}

--- a/clustergroup/values.schema.json
+++ b/clustergroup/values.schema.json
@@ -254,7 +254,14 @@
             "description": "Templated value file paths."
 	},
         "namespaces": {
-          "type": "array",
+          "anyOf": [
+            {
+              "type": "array"
+            },
+            {
+              "type": "object"
+            }
+          ],
           "description": "This is the array of namespaces that the VP framework will create.  In addition, operator groups will also be created for each namespace.",
           "items": {
             "$ref": "#/definitions/Namespaces"
@@ -312,7 +319,14 @@
           }
         },
         "projects": {
-          "type": "array",
+          "anyOf": [
+            {
+              "type": "array"
+            },
+            {
+              "type": "object"
+            }
+          ],
           "description": "The list of projects that will be created in the ArgoCD instances.",
           "items": {
             "type": "string"

--- a/examples/values-example.yaml
+++ b/examples/values-example.yaml
@@ -15,6 +15,18 @@ clusterGroup:
   - /values/{{ .Values.global.clusterPlatform }}.yaml
   - /values/{{ .Values.global.clusterVersion }}.yaml
 
+  # 
+  # You can define namespaces using hashes and not as a list like so:
+  # namespaces:
+  #   open-cluster-management:
+  #     labels:
+  #       openshift.io/node-selector: ""
+  #       kubernetes.io/os: linux
+  #     annotations:
+  #       openshift.io/cluster-monitoring: "true"
+  #       owner: "namespace owner"
+  #   application-ci: 
+  # You cannot mix list and hashes to define namespaces
   namespaces:
   - open-cluster-management:
       labels:
@@ -58,6 +70,12 @@ clusterGroup:
       name: openshift-pipelines-operator-rh
       csv: redhat-openshift-pipelines.v1.5.2
 
+  # 
+  # You can define projects using hashes like so:
+  # projects:
+  #   hub:
+  #   datacenter:
+  # You cannot mix list and hashes to define projects.
   projects:
   - datacenter
 


### PR DESCRIPTION
The changes here support the "Support for merging of namespaces, projects,
subscriptions and application in overrides/values-common.yaml #459" issue that was opened by
Northrop Grumman

Files that were changed are:
clustergroup/templates/_helpers.tpl
clustergroup/templates/core/namespaces.yaml
clustergroup/templates/core/operatorgroup.yaml
clustergroup/templates/plumbing/projects.yaml
clustergroup/values.schema.json
examples/values-example.yaml

The idea is that if you define the projects section, or the namespaces section, in two different
values files using a map construct we will be able to merge both definition of projects into
the final rendering of the manifests.

The new structure for projects is as follows:
```
clusterGroup:
  ...
  projects:
    project1:
```

The new structure for namespaces is as follows:
```
clusterGroup:
  ...
  namespaces:
    namespace1:
    open-cluster-management:
      labels:
        openshift.io/node-selector: ""
        kubernetes.io/os: linux
      annotations:
        openshift.io/cluster-monitoring: "true"
        owner: "namespace owner"
```
The user would need to choose to use a list or a hashmap object.  The user would not be able to use a
mix of hashes and list to describe projects or namespaces.
