### PR TITLE
Support for cluster-wide proxy

### DIFF
--- a/clustergroup/templates/imperative/_helpers.tpl
+++ b/clustergroup/templates/imperative/_helpers.tpl
@@ -58,6 +58,12 @@
         git config --global core.sshCommand "ssh -i "${HOME}/.ssh/id_rsa" -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no";
       fi;
     fi;
+    OUT="$(oc get proxy.config.openshift.io/cluster -o jsonpath='{.spec.httpProxy}' 2>/dev/null)";
+    if [ -n "${OUT}" ]; then export HTTP_PROXY="${OUT}"; fi;
+    OUT="$(oc get proxy.config.openshift.io/cluster -o jsonpath='{.spec.httpsProxy}' 2>/dev/null)";
+    if [ -n "${OUT}" ]; then export HTTPS_PROXY="${OUT}"; fi;
+    OUT="$(oc get proxy.config.openshift.io/cluster -o jsonpath='{.spec.noProxy}' 2>/dev/null)";
+    if [ -n "${OUT}" ]; then export NO_PROXY="${OUT}"; fi;
     mkdir /git/{repo,home};
     git clone --single-branch --branch {{ $.Values.global.targetRevision }} --depth 1 -- "${URL}" /git/repo;
     chmod 0770 /git/{repo,home};
@@ -96,6 +102,12 @@
         git config --global core.sshCommand "ssh -i "${HOME}/.ssh/id_rsa" -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no";
       fi;
     fi;
+    OUT="$(oc get proxy.config.openshift.io/cluster -o jsonpath='{.spec.httpProxy}' 2>/dev/null)";
+    if [ -n "${OUT}" ]; then export HTTP_PROXY="${OUT}"; fi;
+    OUT="$(oc get proxy.config.openshift.io/cluster -o jsonpath='{.spec.httpsProxy}' 2>/dev/null)";
+    if [ -n "${OUT}" ]; then export HTTPS_PROXY="${OUT}"; fi;
+    OUT="$(oc get proxy.config.openshift.io/cluster -o jsonpath='{.spec.noProxy}' 2>/dev/null)";
+    if [ -n "${OUT}" ]; then export NO_PROXY="${OUT}"; fi;
     mkdir /git/{repo,home};
     git clone --single-branch --branch {{ $.Values.global.targetRevision }} --depth 1 -- "${URL}" /git/repo;
     chmod 0770 /git/{repo,home};

--- a/tests/clustergroup-industrial-edge-factory.expected.yaml
+++ b/tests/clustergroup-industrial-edge-factory.expected.yaml
@@ -401,6 +401,12 @@ spec:
                     git config --global core.sshCommand "ssh -i "${HOME}/.ssh/id_rsa" -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no";
                   fi;
                 fi;
+                OUT="$(oc get proxy.config.openshift.io/cluster -o jsonpath='{.spec.httpProxy}' 2>/dev/null)";
+                if [ -n "${OUT}" ]; then export HTTP_PROXY="${OUT}"; fi;
+                OUT="$(oc get proxy.config.openshift.io/cluster -o jsonpath='{.spec.httpsProxy}' 2>/dev/null)";
+                if [ -n "${OUT}" ]; then export HTTPS_PROXY="${OUT}"; fi;
+                OUT="$(oc get proxy.config.openshift.io/cluster -o jsonpath='{.spec.noProxy}' 2>/dev/null)";
+                if [ -n "${OUT}" ]; then export NO_PROXY="${OUT}"; fi;
                 mkdir /git/{repo,home};
                 git clone --single-branch --branch main --depth 1 -- "${URL}" /git/repo;
                 chmod 0770 /git/{repo,home};

--- a/tests/clustergroup-industrial-edge-hub.expected.yaml
+++ b/tests/clustergroup-industrial-edge-hub.expected.yaml
@@ -562,6 +562,12 @@ spec:
                     git config --global core.sshCommand "ssh -i "${HOME}/.ssh/id_rsa" -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no";
                   fi;
                 fi;
+                OUT="$(oc get proxy.config.openshift.io/cluster -o jsonpath='{.spec.httpProxy}' 2>/dev/null)";
+                if [ -n "${OUT}" ]; then export HTTP_PROXY="${OUT}"; fi;
+                OUT="$(oc get proxy.config.openshift.io/cluster -o jsonpath='{.spec.httpsProxy}' 2>/dev/null)";
+                if [ -n "${OUT}" ]; then export HTTPS_PROXY="${OUT}"; fi;
+                OUT="$(oc get proxy.config.openshift.io/cluster -o jsonpath='{.spec.noProxy}' 2>/dev/null)";
+                if [ -n "${OUT}" ]; then export NO_PROXY="${OUT}"; fi;
                 mkdir /git/{repo,home};
                 git clone --single-branch --branch main --depth 1 -- "${URL}" /git/repo;
                 chmod 0770 /git/{repo,home};
@@ -655,6 +661,12 @@ spec:
                     git config --global core.sshCommand "ssh -i "${HOME}/.ssh/id_rsa" -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no";
                   fi;
                 fi;
+                OUT="$(oc get proxy.config.openshift.io/cluster -o jsonpath='{.spec.httpProxy}' 2>/dev/null)";
+                if [ -n "${OUT}" ]; then export HTTP_PROXY="${OUT}"; fi;
+                OUT="$(oc get proxy.config.openshift.io/cluster -o jsonpath='{.spec.httpsProxy}' 2>/dev/null)";
+                if [ -n "${OUT}" ]; then export HTTPS_PROXY="${OUT}"; fi;
+                OUT="$(oc get proxy.config.openshift.io/cluster -o jsonpath='{.spec.noProxy}' 2>/dev/null)";
+                if [ -n "${OUT}" ]; then export NO_PROXY="${OUT}"; fi;
                 mkdir /git/{repo,home};
                 git clone --single-branch --branch main --depth 1 -- "${URL}" /git/repo;
                 chmod 0770 /git/{repo,home};

--- a/tests/clustergroup-medical-diagnosis-hub.expected.yaml
+++ b/tests/clustergroup-medical-diagnosis-hub.expected.yaml
@@ -489,6 +489,12 @@ spec:
                     git config --global core.sshCommand "ssh -i "${HOME}/.ssh/id_rsa" -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no";
                   fi;
                 fi;
+                OUT="$(oc get proxy.config.openshift.io/cluster -o jsonpath='{.spec.httpProxy}' 2>/dev/null)";
+                if [ -n "${OUT}" ]; then export HTTP_PROXY="${OUT}"; fi;
+                OUT="$(oc get proxy.config.openshift.io/cluster -o jsonpath='{.spec.httpsProxy}' 2>/dev/null)";
+                if [ -n "${OUT}" ]; then export HTTPS_PROXY="${OUT}"; fi;
+                OUT="$(oc get proxy.config.openshift.io/cluster -o jsonpath='{.spec.noProxy}' 2>/dev/null)";
+                if [ -n "${OUT}" ]; then export NO_PROXY="${OUT}"; fi;
                 mkdir /git/{repo,home};
                 git clone --single-branch --branch main --depth 1 -- "${URL}" /git/repo;
                 chmod 0770 /git/{repo,home};
@@ -582,6 +588,12 @@ spec:
                     git config --global core.sshCommand "ssh -i "${HOME}/.ssh/id_rsa" -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no";
                   fi;
                 fi;
+                OUT="$(oc get proxy.config.openshift.io/cluster -o jsonpath='{.spec.httpProxy}' 2>/dev/null)";
+                if [ -n "${OUT}" ]; then export HTTP_PROXY="${OUT}"; fi;
+                OUT="$(oc get proxy.config.openshift.io/cluster -o jsonpath='{.spec.httpsProxy}' 2>/dev/null)";
+                if [ -n "${OUT}" ]; then export HTTPS_PROXY="${OUT}"; fi;
+                OUT="$(oc get proxy.config.openshift.io/cluster -o jsonpath='{.spec.noProxy}' 2>/dev/null)";
+                if [ -n "${OUT}" ]; then export NO_PROXY="${OUT}"; fi;
                 mkdir /git/{repo,home};
                 git clone --single-branch --branch main --depth 1 -- "${URL}" /git/repo;
                 chmod 0770 /git/{repo,home};

--- a/tests/clustergroup-naked.expected.yaml
+++ b/tests/clustergroup-naked.expected.yaml
@@ -254,6 +254,12 @@ spec:
                     git config --global core.sshCommand "ssh -i "${HOME}/.ssh/id_rsa" -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no";
                   fi;
                 fi;
+                OUT="$(oc get proxy.config.openshift.io/cluster -o jsonpath='{.spec.httpProxy}' 2>/dev/null)";
+                if [ -n "${OUT}" ]; then export HTTP_PROXY="${OUT}"; fi;
+                OUT="$(oc get proxy.config.openshift.io/cluster -o jsonpath='{.spec.httpsProxy}' 2>/dev/null)";
+                if [ -n "${OUT}" ]; then export HTTPS_PROXY="${OUT}"; fi;
+                OUT="$(oc get proxy.config.openshift.io/cluster -o jsonpath='{.spec.noProxy}' 2>/dev/null)";
+                if [ -n "${OUT}" ]; then export NO_PROXY="${OUT}"; fi;
                 mkdir /git/{repo,home};
                 git clone --single-branch --branch main --depth 1 -- "${URL}" /git/repo;
                 chmod 0770 /git/{repo,home};

--- a/tests/clustergroup-normal.expected.yaml
+++ b/tests/clustergroup-normal.expected.yaml
@@ -451,6 +451,12 @@ spec:
                     git config --global core.sshCommand "ssh -i "${HOME}/.ssh/id_rsa" -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no";
                   fi;
                 fi;
+                OUT="$(oc get proxy.config.openshift.io/cluster -o jsonpath='{.spec.httpProxy}' 2>/dev/null)";
+                if [ -n "${OUT}" ]; then export HTTP_PROXY="${OUT}"; fi;
+                OUT="$(oc get proxy.config.openshift.io/cluster -o jsonpath='{.spec.httpsProxy}' 2>/dev/null)";
+                if [ -n "${OUT}" ]; then export HTTPS_PROXY="${OUT}"; fi;
+                OUT="$(oc get proxy.config.openshift.io/cluster -o jsonpath='{.spec.noProxy}' 2>/dev/null)";
+                if [ -n "${OUT}" ]; then export NO_PROXY="${OUT}"; fi;
                 mkdir /git/{repo,home};
                 git clone --single-branch --branch main --depth 1 -- "${URL}" /git/repo;
                 chmod 0770 /git/{repo,home};
@@ -544,6 +550,12 @@ spec:
                     git config --global core.sshCommand "ssh -i "${HOME}/.ssh/id_rsa" -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no";
                   fi;
                 fi;
+                OUT="$(oc get proxy.config.openshift.io/cluster -o jsonpath='{.spec.httpProxy}' 2>/dev/null)";
+                if [ -n "${OUT}" ]; then export HTTP_PROXY="${OUT}"; fi;
+                OUT="$(oc get proxy.config.openshift.io/cluster -o jsonpath='{.spec.httpsProxy}' 2>/dev/null)";
+                if [ -n "${OUT}" ]; then export HTTPS_PROXY="${OUT}"; fi;
+                OUT="$(oc get proxy.config.openshift.io/cluster -o jsonpath='{.spec.noProxy}' 2>/dev/null)";
+                if [ -n "${OUT}" ]; then export NO_PROXY="${OUT}"; fi;
                 mkdir /git/{repo,home};
                 git clone --single-branch --branch main --depth 1 -- "${URL}" /git/repo;
                 chmod 0770 /git/{repo,home};


### PR DESCRIPTION
If the clusterwide proxy object is configured, let's support it when
we clone the git repos for the imperative framework.
