### PR TITLE
feat: use hive clusterdeployment for creating spoke clusters

### DIFF
--- a/acm/templates/provision/clusterdeployment.yaml
+++ b/acm/templates/provision/clusterdeployment.yaml
@@ -3,6 +3,14 @@
 
 {{- range $group.clusterDeployments}}
 {{ $cluster := . }}
+
+{{- if (eq $cluster.name nil) }}
+{{- fail (printf "managedClusterGroup clusterDeployment cluster name is empty: %s" $cluster) }}
+{{- end }}
+{{- if (eq $group.name nil) }}
+{{- fail (printf "managedClusterGroup clusterDeployment group name is empty: %s" $cluster) }}
+{{- end }}
+
 {{- $deploymentName := print $cluster.name "-" $group.name }}
 
 {{- $cloud := "None" }}
@@ -30,6 +38,8 @@ metadata:
   namespace: {{ $deploymentName }}
   labels:
     vendor: OpenShift
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   baseDomain: {{ $cluster.baseDomain }}
   clusterName: {{ $deploymentName }}
@@ -65,6 +75,8 @@ metadata:
     {{- end }}
   {{- end }}
   name: {{ $deploymentName }}
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   hubAcceptsClient: true
 {{- end }}{{- /* range $group.clusterDeployments */}}

--- a/acm/templates/provision/clusterdeployment.yaml
+++ b/acm/templates/provision/clusterdeployment.yaml
@@ -1,0 +1,71 @@
+{{- range .Values.clusterGroup.managedClusterGroups }}
+{{- $group := . }}
+
+{{- range $group.clusterDeployments}}
+{{ $cluster := . }}
+{{- $deploymentName := print $cluster.name "-" $group.name }}
+
+{{- $cloud := "None" }}
+{{- $region := "None" }}
+
+{{- if $cluster.platform.aws }}
+{{- $cloud = "aws" }}
+{{- $region = $cluster.platform.aws.region }}
+{{- else if $cluster.platform.azure }}
+{{- $cloud = "azure" }}
+{{- $region = $cluster.platform.azure.region }}
+{{- end }}
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ $deploymentName }}
+
+---
+apiVersion: hive.openshift.io/v1
+kind: ClusterDeployment
+metadata:
+  name: {{ $deploymentName }}
+  namespace: {{ $deploymentName }}
+  labels:
+    vendor: OpenShift
+spec:
+  baseDomain: {{ $cluster.baseDomain }}
+  clusterName: {{ $deploymentName }}
+  installAttemptsLimit: 1
+  platform:
+    {{ $cloud }}:
+      credentialsSecretRef:
+        name: {{ $deploymentName }}-creds
+      region: {{ $region }}
+  provisioning:
+    installConfigSecretRef:
+      name: {{ $deploymentName }}-install-config
+    sshPrivateKeySecretRef:
+      name: {{ $deploymentName }}-ssh-private-key
+    imageSetRef:
+      name: img{{ $cluster.openshiftVersion }}-multi-appsub
+  pullSecretRef:
+    name: {{ $deploymentName }}-pull-secret
+
+---
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  labels:
+    cluster.open-cluster-management.io/clusterset: {{ $group.name }}
+  {{- if (not $group.acmlabels) }}
+    clusterGroup: {{ $group.name }}
+  {{- else if eq (len $group.acmlabels) 0 }}
+    clusterGroup: {{ $group.name }}
+  {{- else }}
+    {{- range $group.acmlabels }}
+    {{ .name }}: {{ .value }}
+    {{- end }}
+  {{- end }}
+  name: {{ $deploymentName }}
+spec:
+  hubAcceptsClient: true
+{{- end }}{{- /* range $group.clusterDeployments */}}
+{{- end }}{{- /* range .Values.clusterGroup.managedClusterGroups */}}

--- a/acm/templates/provision/clusterpool.yaml
+++ b/acm/templates/provision/clusterpool.yaml
@@ -1,17 +1,5 @@
 {{- range .Values.clusterGroup.managedClusterGroups }}
 {{- $group := . }}
-{{- if .clusterPools }}{{- /* We only create ManagedClusterSets if there are clusterPools defined */}}
-apiVersion: cluster.open-cluster-management.io/v1beta1
-kind: ManagedClusterSet
-metadata:
-  annotations:
-    cluster.open-cluster-management.io/submariner-broker-ns: {{ .name }}-broker
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-  name: {{ .name }}
-spec:
-  clusterSelector:
-    selectorType: LegacyClusterSetLabel
----
 {{- range .clusterPools }}
 
 {{- $pool := . }}
@@ -54,7 +42,7 @@ spec:
   runningCount: {{ $numClusters }}
   baseDomain: {{ .baseDomain }}
   installConfigSecretTemplateRef:
-    name: {{ $poolName }}-install-config 
+    name: {{ $poolName }}-install-config
   imageSetRef:
     name: img{{ .openshiftVersion }}-multi-appsub
   pullSecretRef:
@@ -91,5 +79,4 @@ spec:
 ---
 {{- end }}{{- /* range .range clusters */}}
 {{- end }}{{- /* range .clusterPools */}}
-{{- end }}{{- /* if .clusterPools) */}}
 {{- end }}{{- /* range .Values.clusterGroup.managedClusterGroups */}}

--- a/acm/templates/provision/managedclusterset.yaml
+++ b/acm/templates/provision/managedclusterset.yaml
@@ -1,0 +1,16 @@
+{{- range .Values.clusterGroup.managedClusterGroups }}
+{{- if or .clusterPools .clusterDeployments }}{{- /* We only create ManagedClusterSets if there are clusterPools or clusterDeployments defined */}}
+---
+apiVersion: cluster.open-cluster-management.io/v1beta2
+kind: ManagedClusterSet
+metadata:
+  annotations:
+    cluster.open-cluster-management.io/submariner-broker-ns: {{ .name }}-broker
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  name: {{ .name }}
+spec:
+  clusterSelector:
+    selectorType: LegacyClusterSetLabel
+
+{{- end }}{{- /* if .clusterPools) */}}
+{{- end }}{{- /* range .Values.clusterGroup.managedClusterGroups */}}

--- a/acm/templates/provision/managedclusterset.yaml
+++ b/acm/templates/provision/managedclusterset.yaml
@@ -8,9 +8,6 @@ metadata:
     cluster.open-cluster-management.io/submariner-broker-ns: {{ .name }}-broker
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   name: {{ .name }}
-spec:
-  clusterSelector:
-    selectorType: LegacyClusterSetLabel
 
 {{- end }}{{- /* if .clusterPools) */}}
 {{- end }}{{- /* range .Values.clusterGroup.managedClusterGroups */}}

--- a/acm/templates/provision/secrets-aws.yaml
+++ b/acm/templates/provision/secrets-aws.yaml
@@ -3,58 +3,82 @@
 {{- range .clusterPools }}
 {{- $poolName := print .name "-" $group.name }}
 {{- if .platform.aws }}
+---
+{{- template "externalsecret.aws.creds" (dict "name" $poolName "context" . "secretStore" $.Values.secretStore) }}
+---
+{{- template "externalsecret.aws.infra-creds" (dict "name" $poolName "context" . "secretStore" $.Values.secretStore) }}
+
+{{- end }}{{- /* if .platform.aws */}}
+{{- end }}{{- /* range .clusterPools  */}}
+
+{{- range .clusterDeployments }}
+{{- $deploymentName := print .name "-" $group.name }}
+{{- if .platform.aws }}
+---
+{{- template "externalsecret.aws.creds" (dict "name" $deploymentName "context" . "secretStore" $.Values.secretStore) }}
+---
+{{- template "externalsecret.aws.infra-creds" (dict "name" $deploymentName "context" . "secretStore" $.Values.secretStore) }}
+
+{{- end }}{{- /* if .platform.aws */}}
+{{- end }}{{- /* range .clusterDeployments  */}}
+
+{{- end }}{{- /* range .Values.clusterGroup.managedClusterGroups */}}
+
+{{- define "externalsecret.aws.creds" }}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: {{ $poolName }}-creds
+  name: {{ .name }}-creds
 spec:
   dataFrom:
   - extract:
       # Expects entries called: aws_access_key_id and aws_secret_access_key
-      key: {{ default "secret/data/hub/aws" .awsKeyPath }}
+      key: {{ default "secret/data/hub/aws" .context.awsKeyPath }}
   refreshInterval: 24h0m0s
   secretStoreRef:
-    name: {{ $.Values.secretStore.name }}
-    kind: {{ $.Values.secretStore.kind }}
+    name: {{ .secretStore.name }}
+    kind: {{ .secretStore.kind }}
   target:
-    name: {{ $poolName }}-creds
+    name: {{ .name }}-creds
     creationPolicy: Owner
     template:
       type: Opaque
----
+{{- end}}
+
+{{- define "externalsecret.aws.infra-creds"}}
 # For use when manually creating clusters with ACM
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: {{ $poolName }}-infra-creds
-spec: 
+  name: {{ .name }}-infra-creds
+spec:
   data:
   - secretKey: openshiftPullSecret
     remoteRef:
-      key: {{ default "secret/data/hub/openshiftPullSecret" .pullSecretKeyPath }}
+      key: {{ default "secret/data/hub/openshiftPullSecret" .context.pullSecretKeyPath }}
       property: content
   - secretKey: awsKeyId
     remoteRef:
-      key: {{ default "secret/data/hub/aws" .awsKeyPath }}
+      key: {{ default "secret/data/hub/aws" .context.awsKeyPath }}
       property: aws_access_key_id
   - secretKey: awsAccessKey
     remoteRef:
-      key: {{ default "secret/data/hub/aws" .awsKeyPath }}
+      key: {{ default "secret/data/hub/aws" .context.awsKeyPath }}
       property: aws_secret_access_key
   - secretKey: sshPublicKey
     remoteRef:
-      key: {{ default "secret/data/hub/publickey" .sshPublicKeyPath }}
+      key: {{ default "secret/data/hub/publickey" .context.sshPublicKeyPath }}
       property: content
   - secretKey: sshPrivateKey
     remoteRef:
-      key: {{ default "secret/data/hub/privatekey" .sshPrivateKeyPath }}
+      key: {{ default "secret/data/hub/privatekey" .context.sshPrivateKeyPath }}
       property: content
   refreshInterval: 24h0m0s
-  secretStoreRef: 
-    name: {{ $.Values.secretStore.name }}
-    kind: {{ $.Values.secretStore.kind }}
+  secretStoreRef:
+    name: {{ .secretStore.name }}
+    kind: {{ .secretStore.kind }}
   target:
-    name: {{ $poolName }}-infra-creds
+    name: {{ .name }}-infra-creds
     creationPolicy: Owner
     template:
       type: Opaque
@@ -63,7 +87,7 @@ spec:
           cluster.open-cluster-management.io/credentials: ""
           cluster.open-cluster-management.io/type: aws
       data:
-        baseDomain: "{{ .baseDomain }}"
+        baseDomain: "{{ .context.baseDomain }}"
         pullSecret: |-
           {{ "{{ .openshiftPullSecret | toString }}" }}
         aws_access_key_id: |-
@@ -78,7 +102,4 @@ spec:
         httpsProxy: ""
         noProxy: ""
         additionalTrustBundle: ""
----
-{{- end }}
-{{- end }}
-{{- end }}
+{{- end}}

--- a/acm/templates/provision/secrets-aws.yaml
+++ b/acm/templates/provision/secrets-aws.yaml
@@ -15,9 +15,9 @@
 {{- $deploymentName := print .name "-" $group.name }}
 {{- if .platform.aws }}
 ---
-{{- template "externalsecret.aws.creds" (dict "name" $deploymentName "context" . "secretStore" $.Values.secretStore) }}
+{{- template "externalsecret.aws.creds" (dict "name" $deploymentName "context" . "secretStore" $.Values.secretStore "namespaced" true) }}
 ---
-{{- template "externalsecret.aws.infra-creds" (dict "name" $deploymentName "context" . "secretStore" $.Values.secretStore) }}
+{{- template "externalsecret.aws.infra-creds" (dict "name" $deploymentName "context" . "secretStore" $.Values.secretStore "namespaced" true) }}
 
 {{- end }}{{- /* if .platform.aws */}}
 {{- end }}{{- /* range .clusterDeployments  */}}
@@ -29,6 +29,9 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: {{ .name }}-creds
+  {{- if .namespaced }}
+  namespace: {{ .name }}
+  {{- end }}
 spec:
   dataFrom:
   - extract:
@@ -51,6 +54,9 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: {{ .name }}-infra-creds
+  {{- if .namespaced }}
+  namespace: {{ .name }}
+  {{- end }}
 spec:
   data:
   - secretKey: openshiftPullSecret

--- a/acm/templates/provision/secrets-azure.yaml
+++ b/acm/templates/provision/secrets-azure.yaml
@@ -3,58 +3,84 @@
 {{- range .clusterPools }}
 {{- $poolName := print .name "-" $group.name }}
 {{- if .platform.azure }}
+---
+{{- template "externalsecret.azure.creds" (dict "name" $poolName "context" . "secretStore" $.Values.secretStore) }}
+---
+{{- template "externalsecret.azure.infra-creds" (dict "name" $poolName "context" . "secretStore" $.Values.secretStore) }}
+
+---
+{{- end }}{{- /* if .platform.azure */}}
+{{- end }}{{- /* range .clusterPools  */}}
+
+{{- range .clusterDeployments }}
+{{- $deploymentName := print .name "-" $group.name }}
+{{- if .platform.azure }}
+---
+{{- template "externalsecret.azure.creds" (dict "name" $deploymentName "context" . "secretStore" $.Values.secretStore) }}
+---
+{{- template "externalsecret.azure.infra-creds" (dict "name" $deploymentName "context" . "secretStore" $.Values.secretStore) }}
+
+
+{{- end }}{{- /* if .platform.azure */}}
+{{- end }}{{- /* range .clusterPools  */}}
+
+{{- end }}{{- /* range .Values.clusterGroup.managedClusterGroups  */}}
+
+{{- define "externalsecret.azure.creds" }}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: {{ $poolName }}-creds
+  name: {{ .name }}-creds
 spec:
   data:
   - secretKey: azureOsServicePrincipal
     remoteRef:
-      key: {{ default "secret/data/hub/azureOsServicePrincipal" .azureKeyPath }}
+      key: {{ default "secret/data/hub/azureOsServicePrincipal" .context.azureKeyPath }}
       property: content
   refreshInterval: 24h0m0s
   secretStoreRef:
-    name: {{ $.Values.secretStore.name }}
-    kind: {{ $.Values.secretStore.kind }}
+    name: {{ .secretStore.name }}
+    kind: {{ .secretStore.kind }}
   target:
-    name: {{ $poolName }}-creds
+    name: {{ .name }}-creds
     creationPolicy: Owner
     template:
       type: Opaque
       data:
         osServicePrincipal.json: |-
           {{ "{{ .azureOsServicePrincipal | toString }}" }}
----
+{{- end }}
+
+{{- define "externalsecret.azure.infra-creds"}}
 # For use when manually creating clusters with ACM
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: {{ $poolName }}-infra-creds
-spec: 
+  name: {{ .name }}-infra-creds
+spec:
   data:
   - secretKey: openshiftPullSecret
     remoteRef:
-      key: {{ default "secret/data/hub/openshiftPullSecret" .pullSecretKeyPath }}
+      key: {{ default "secret/data/hub/openshiftPullSecret" .context.pullSecretKeyPath }}
       property: content
   - secretKey: sshPublicKey
     remoteRef:
-      key: {{ default "secret/data/hub/publickey" .sshPublicKeyPath }}
+      key: {{ default "secret/data/hub/publickey" .context.sshPublicKeyPath }}
       property: content
   - secretKey: sshPrivateKey
     remoteRef:
-      key: {{ default "secret/data/hub/privatekey" .sshPrivateKeyPath }}
+      key: {{ default "secret/data/hub/privatekey" .context.sshPrivateKeyPath }}
       property: content
   - secretKey: azureOsServicePrincipal
     remoteRef:
-      key: {{ default "secret/data/hub/azureOsServicePrincipal" .azureKeyPath }}
+      key: {{ default "secret/data/hub/azureOsServicePrincipal" .context.azureKeyPath }}
       property: content
   refreshInterval: 24h0m0s
-  secretStoreRef: 
-    name: {{ $.Values.secretStore.name }}
-    kind: {{ $.Values.secretStore.kind }}
+  secretStoreRef:
+    name: {{ .secretStore.name }}
+    kind: {{ .secretStore.kind }}
   target:
-    name: {{ $poolName }}-infra-creds
+    name: {{ .name }}-infra-creds
     creationPolicy: Owner
     template:
       type: Opaque
@@ -66,8 +92,8 @@ spec:
         cloudName: AzurePublicCloud
         osServicePrincipal.json: |-
           {{ "{{ .azureOsServicePrincipal | toString }}" }}
-        baseDomain: "{{ .baseDomain }}"
-        baseDomainResourceGroupName: "{{ .platform.azure.baseDomainResourceGroupName | toString }}"
+        baseDomain: "{{ .context.baseDomain }}"
+        baseDomainResourceGroupName: "{{ .context.platform.azure.baseDomainResourceGroupName | toString }}"
         pullSecret: |-
           {{ "{{ .openshiftPullSecret | toString }}" }}
         ssh-privatekey: |-
@@ -78,7 +104,4 @@ spec:
         httpsProxy: ""
         noProxy: ""
         additionalTrustBundle: ""
----
-{{- end }}
-{{- end }}
 {{- end }}

--- a/acm/templates/provision/secrets-azure.yaml
+++ b/acm/templates/provision/secrets-azure.yaml
@@ -16,9 +16,9 @@
 {{- $deploymentName := print .name "-" $group.name }}
 {{- if .platform.azure }}
 ---
-{{- template "externalsecret.azure.creds" (dict "name" $deploymentName "context" . "secretStore" $.Values.secretStore) }}
+{{- template "externalsecret.azure.creds" (dict "name" $deploymentName "context" . "secretStore" $.Values.secretStore "namespaced" true) }}
 ---
-{{- template "externalsecret.azure.infra-creds" (dict "name" $deploymentName "context" . "secretStore" $.Values.secretStore) }}
+{{- template "externalsecret.azure.infra-creds" (dict "name" $deploymentName "context" . "secretStore" $.Values.secretStore "namespaced" true) }}
 
 
 {{- end }}{{- /* if .platform.azure */}}
@@ -31,6 +31,9 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: {{ .name }}-creds
+  {{- if .namespaced }}
+  namespace: {{ .name }}
+  {{- end }}
 spec:
   data:
   - secretKey: azureOsServicePrincipal
@@ -57,6 +60,9 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: {{ .name }}-infra-creds
+  {{- if .namespaced }}
+  namespace: {{ .name }}
+  {{- end }}
 spec:
   data:
   - secretKey: openshiftPullSecret

--- a/acm/templates/provision/secrets-common.yaml
+++ b/acm/templates/provision/secrets-common.yaml
@@ -1,61 +1,86 @@
 {{- range .Values.clusterGroup.managedClusterGroups }}
 {{- $group := . }}
+
 {{- range .clusterPools }}
 {{- $poolName := print .name "-" $group.name }}
+---
+{{- template "secret.install-config" (dict "name" $poolName "context" .) }}
+---
+{{- template "externalsecret.pull-secret" (dict "name" $poolName "context" . "secretStore" $.Values.secretStore) }}
+---
+{{- template "externalsecret.ssh.private.key" (dict "name" $poolName "context" . "secretStore" $.Values.secretStore) }}
+{{- end }}{{- /* range .clusterPools */}}
+
+{{- range .clusterDeployments }}
+{{- $deploymentName := print .name "-" $group.name }}
+---
+{{- template "secret.install-config" (dict "name" $deploymentName "context" .) }}
+---
+{{- template "externalsecret.pull-secret" (dict "name" $deploymentName "context" . "secretStore" $.Values.secretStore) }}
+---
+{{- template "externalsecret.ssh.private.key" (dict "name" $deploymentName "context" . "secretStore" $.Values.secretStore) }}
+{{- end }}{{- /* range .clusterDeplyments */}}
+
+{{- end }}{{- /* range .Values.clusterGroup.managedClusterGroups */}}
+
+{{- define "secret.install-config"}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ $poolName }}-install-config
+  name: {{ .name }}-install-config
 data:
   # Base64 encoding of install-config yaml
-  install-config.yaml: {{ include "cluster.install-config" . | b64enc }} 
+  install-config.yaml: {{ include "cluster.install-config" .context | b64enc }}
 type: Opaque
----
+{{- end }}
+
+{{- define "externalsecret.pull-secret" }}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: {{ $poolName }}-pull-secret
-spec: 
+  name: {{ .name }}-pull-secret
+spec:
   data:
   - secretKey: openshiftPullSecret
     remoteRef:
-      key: {{ default "secret/data/hub/openshiftPullSecret" .pullSecretKeyPath }}
+      key: {{ default "secret/data/hub/openshiftPullSecret" .context.pullSecretKeyPath }}
       property: content
   refreshInterval: 24h0m0s
   secretStoreRef:
-    name: {{ $.Values.secretStore.name }}
-    kind: {{ $.Values.secretStore.kind }}
+    name: {{ .secretStore.name }}
+    kind: {{ .secretStore.kind }}
   target:
-    name: {{ $poolName }}-pull-secret
+    name: {{ .name }}-pull-secret
     creationPolicy: Owner
     template:
       type: kubernetes.io/dockerconfigjson
       data:
         .dockerconfigjson: |-
           {{ "{{ .openshiftPullSecret | toString }}" }}
----
+{{- end }}
+
+
+{{- define "externalsecret.ssh.private.key" }}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: {{ $poolName }}-ssh-private-key
+  name: {{ .name }}-ssh-private-key
 spec:
   data:
   - secretKey: sshPrivateKey
     remoteRef:
-      key: {{ default "secret/data/hub/privatekey" .sshPrivateKeyPath }}
+      key: {{ default "secret/data/hub/privatekey" .context.sshPrivateKeyPath }}
       property: content
   refreshInterval: 24h0m0s
   secretStoreRef:
-    name: {{ $.Values.secretStore.name }}
-    kind: {{ $.Values.secretStore.kind }}
+    name: {{ .secretStore.name }}
+    kind: {{ .secretStore.kind }}
   target:
-    name: {{ $poolName }}-ssh-private-key
+    name: {{ .name }}-ssh-private-key
     creationPolicy: Owner
     template:
       type: Opaque
       data:
         ssh-privatekey: |-
           {{ "{{ .sshPrivateKey | toString }}" }}
----
-{{- end }}
 {{- end }}

--- a/acm/templates/provision/secrets-common.yaml
+++ b/acm/templates/provision/secrets-common.yaml
@@ -14,11 +14,11 @@
 {{- range .clusterDeployments }}
 {{- $deploymentName := print .name "-" $group.name }}
 ---
-{{- template "secret.install-config" (dict "name" $deploymentName "context" .) }}
+{{- template "secret.install-config" (dict "name" $deploymentName "context" . "namespaced" true) }}
 ---
-{{- template "externalsecret.pull-secret" (dict "name" $deploymentName "context" . "secretStore" $.Values.secretStore) }}
+{{- template "externalsecret.pull-secret" (dict "name" $deploymentName "context" . "secretStore" $.Values.secretStore "namespaced" true) }}
 ---
-{{- template "externalsecret.ssh.private.key" (dict "name" $deploymentName "context" . "secretStore" $.Values.secretStore) }}
+{{- template "externalsecret.ssh.private.key" (dict "name" $deploymentName "context" . "secretStore" $.Values.secretStore "namespaced" true) }}
 {{- end }}{{- /* range .clusterDeplyments */}}
 
 {{- end }}{{- /* range .Values.clusterGroup.managedClusterGroups */}}
@@ -28,6 +28,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .name }}-install-config
+  {{- if .namespaced }}
+  namespace: {{ .name }}
+  {{- end }}
 data:
   # Base64 encoding of install-config yaml
   install-config.yaml: {{ include "cluster.install-config" .context | b64enc }}
@@ -39,6 +42,9 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: {{ .name }}-pull-secret
+  {{- if .namespaced }}
+  namespace: {{ .name }}
+  {{- end }}
 spec:
   data:
   - secretKey: openshiftPullSecret
@@ -65,6 +71,9 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: {{ .name }}-ssh-private-key
+  {{- if .namespaced }}
+  namespace: {{ .name }}
+  {{- end }}
 spec:
   data:
   - secretKey: sshPrivateKey

--- a/acm/values.yaml
+++ b/acm/values.yaml
@@ -21,14 +21,29 @@ clusterGroup:
 #        testPool:
 #          name: spoke
 #          openshiftVersion: 4.10.18
-#          provider:
-#            region: ap-southeast-2
-#            baseDomain: blueprints.rhecoeng.com
+#          baseDomain: blueprints.rhecoeng.com
+#          platform:
+#            aws:
+#              region: ap-southeast-2
 #          clusters:
 #          - spoke1
 #      labels:
 #      - name: clusterGroup
 #        value: region-one
+#    testRegionTwo:
+#      name: region-two
+#      clusterDeployments:
+#        myFirstCluster:
+#          name: mcluster1
+#          openshiftVersion: 4.10.18
+#          baseDomain: blueprints.rhecoeng.com
+#          platform:
+#            azure:
+#              baseDomainResourceGroupName: dojo-dns-zones
+#              region: eastus
+#      labels:
+#        - name: clusterGroup
+#          value: region-two
 
 secretStore:
   name: vault-backend

--- a/clustergroup/values.schema.json
+++ b/clustergroup/values.schema.json
@@ -741,6 +741,12 @@
             "$ref": "#/definitions/ClusterPools"
           }
         },
+        "clusterDeployments": {
+          "type": "object",
+          "items": {
+            "$ref": "#/definitions/ClusterDeployments"
+          }
+        },
         "clusterSelector": {
           "type": "object",
           "additionalProperties": true
@@ -787,6 +793,32 @@
         "clusters"
       ],
       "title": "ClusterPools"
+    },
+    "ClusterDeployments": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "openshiftVersion": {
+          "type": "string"
+        },
+        "baseDomain": {
+          "type": "string"
+        },
+        "platform": {
+          "type": "object",
+          "$ref": "#/definitions/ClusterPoolsPlatform"
+        }
+      },
+      "required": [
+        "name",
+        "openshiftVersion",
+        "baseDomain",
+        "platform"
+      ],
+      "title": "ClusterDeployments"
     },
     "ClusterPoolsPlatform": {
       "type": "object",

--- a/examples/values-example.yaml
+++ b/examples/values-example.yaml
@@ -15,7 +15,7 @@ clusterGroup:
   - /values/{{ .Values.global.clusterPlatform }}.yaml
   - /values/{{ .Values.global.clusterVersion }}.yaml
 
-  # 
+  #
   # You can define namespaces using hashes and not as a list like so:
   # namespaces:
   #   open-cluster-management:
@@ -25,7 +25,7 @@ clusterGroup:
   #     annotations:
   #       openshift.io/cluster-monitoring: "true"
   #       owner: "namespace owner"
-  #   application-ci: 
+  #   application-ci:
   # You cannot mix list and hashes to define namespaces
   namespaces:
   - open-cluster-management:
@@ -70,7 +70,7 @@ clusterGroup:
       name: openshift-pipelines-operator-rh
       csv: redhat-openshift-pipelines.v1.5.2
 
-  # 
+  #
   # You can define projects using hashes like so:
   # projects:
   #   hub:
@@ -159,9 +159,26 @@ clusterGroup:
         clusters:
         - Two
         - three
+    clusterDeployments:
+      myFirstCluster:
+        name: aws-cd-one-w-pool
+        openshiftVersion: 4.10.18
+        baseDomain: blueprints.rhecoeng.com
+        platform:
+          aws:
+            region: ap-southeast-1
     acmlabels:
     - name: clusterGroup
       value: region
+  - name: acm-provision-on-deploy
+    clusterDeployments:
+      mySecondCluster:
+        name: aws-cd-two-wo-pool
+        openshiftVersion: 4.10.18
+        baseDomain: blueprints.rhecoeng.com
+        platform:
+          aws:
+            region: ap-southeast-3
   - name: argo-edge
     hostedArgoSites:
     - name: perth

--- a/tests/acm-normal.expected.yaml
+++ b/tests/acm-normal.expected.yaml
@@ -6,7 +6,7 @@ metadata:
   name: aws-ap-acm-provision-edge-install-config
 data:
   # Base64 encoding of install-config yaml
-  install-config.yaml: CgphcGlWZXJzaW9uOiB2MQptZXRhZGF0YToKICBuYW1lOiAnYXdzLWFwJyAKYmFzZURvbWFpbjogYmx1ZXByaW50cy5yaGVjb2VuZy5jb20KY29udHJvbFBsYW5lOgogIGFyY2hpdGVjdHVyZTogYW1kNjQKICBoeXBlcnRocmVhZGluZzogRW5hYmxlZAogIG5hbWU6IGNvbnRyb2xQbGFuZQogIHJlcGxpY2FzOiAxCiAgcGxhdGZvcm06CiAgICBhd3M6CiAgICAgIHR5cGU6IG01LnhsYXJnZQpjb21wdXRlOgotIGh5cGVydGhyZWFkaW5nOiBFbmFibGVkCiAgYXJjaGl0ZWN0dXJlOiBhbWQ2NAogIG5hbWU6ICd3b3JrZXInCiAgcmVwbGljYXM6IDAKbmV0d29ya2luZzoKICBjbHVzdGVyTmV0d29yazoKICAtIGNpZHI6IDEwLjEyOC4wLjAvMTQKICAgIGhvc3RQcmVmaXg6IDIzCiAgbWFjaGluZU5ldHdvcms6CiAgLSBjaWRyOiAxMC4wLjAuMC8xNgogIG5ldHdvcmtUeXBlOiBPVk5LdWJlcm5ldGVzCiAgc2VydmljZU5ldHdvcms6CiAgLSAxNzIuMzAuMC4wLzE2CnBsYXRmb3JtOgogIGF3czoKICAgIHJlZ2lvbjogYXAtc291dGhlYXN0LTIKcHVsbFNlY3JldDogIiIgIyBza2lwLCBoaXZlIHdpbGwgaW5qZWN0IGJhc2VkIG9uIGl0J3Mgc2VjcmV0cwpzc2hLZXk6ICIiICAgICAjIHNraXAsIGhpdmUgd2lsbCBpbmplY3QgYmFzZWQgb24gaXQncyBzZWNyZXRz 
+  install-config.yaml: CgphcGlWZXJzaW9uOiB2MQptZXRhZGF0YToKICBuYW1lOiAnYXdzLWFwJyAKYmFzZURvbWFpbjogYmx1ZXByaW50cy5yaGVjb2VuZy5jb20KY29udHJvbFBsYW5lOgogIGFyY2hpdGVjdHVyZTogYW1kNjQKICBoeXBlcnRocmVhZGluZzogRW5hYmxlZAogIG5hbWU6IGNvbnRyb2xQbGFuZQogIHJlcGxpY2FzOiAxCiAgcGxhdGZvcm06CiAgICBhd3M6CiAgICAgIHR5cGU6IG01LnhsYXJnZQpjb21wdXRlOgotIGh5cGVydGhyZWFkaW5nOiBFbmFibGVkCiAgYXJjaGl0ZWN0dXJlOiBhbWQ2NAogIG5hbWU6ICd3b3JrZXInCiAgcmVwbGljYXM6IDAKbmV0d29ya2luZzoKICBjbHVzdGVyTmV0d29yazoKICAtIGNpZHI6IDEwLjEyOC4wLjAvMTQKICAgIGhvc3RQcmVmaXg6IDIzCiAgbWFjaGluZU5ldHdvcms6CiAgLSBjaWRyOiAxMC4wLjAuMC8xNgogIG5ldHdvcmtUeXBlOiBPVk5LdWJlcm5ldGVzCiAgc2VydmljZU5ldHdvcms6CiAgLSAxNzIuMzAuMC4wLzE2CnBsYXRmb3JtOgogIGF3czoKICAgIHJlZ2lvbjogYXAtc291dGhlYXN0LTIKcHVsbFNlY3JldDogIiIgIyBza2lwLCBoaXZlIHdpbGwgaW5qZWN0IGJhc2VkIG9uIGl0J3Mgc2VjcmV0cwpzc2hLZXk6ICIiICAgICAjIHNraXAsIGhpdmUgd2lsbCBpbmplY3QgYmFzZWQgb24gaXQncyBzZWNyZXRz
 type: Opaque
 ---
 # Source: acm/templates/provision/secrets-common.yaml
@@ -16,7 +16,7 @@ metadata:
   name: azure-us-acm-provision-edge-install-config
 data:
   # Base64 encoding of install-config yaml
-  install-config.yaml: CgphcGlWZXJzaW9uOiB2MQptZXRhZGF0YToKICBuYW1lOiAnYXp1cmUtdXMnIApiYXNlRG9tYWluOiBibHVlcHJpbnRzLnJoZWNvZW5nLmNvbQpjb250cm9sUGxhbmU6CiAgYXJjaGl0ZWN0dXJlOiBhbWQ2NAogIGh5cGVydGhyZWFkaW5nOiBFbmFibGVkCiAgbmFtZTogY29udHJvbFBsYW5lCiAgcmVwbGljYXM6IDMKICBwbGF0Zm9ybToKICAgIGF6dXJlOgogICAgICB0eXBlOiBTdGFuZGFyZF9EOHNfdjMKY29tcHV0ZToKLSBoeXBlcnRocmVhZGluZzogRW5hYmxlZAogIGFyY2hpdGVjdHVyZTogYW1kNjQKICBuYW1lOiAnd29ya2VyJwogIHJlcGxpY2FzOiAzCiAgcGxhdGZvcm06CiAgICBhenVyZToKICAgICAgdHlwZTogU3RhbmRhcmRfRDhzX3YzCm5ldHdvcmtpbmc6CiAgY2x1c3Rlck5ldHdvcms6CiAgLSBjaWRyOiAxMC4xMjguMC4wLzE0CiAgICBob3N0UHJlZml4OiAyMwogIG1hY2hpbmVOZXR3b3JrOgogIC0gY2lkcjogMTAuMC4wLjAvMTYKICBuZXR3b3JrVHlwZTogT1ZOS3ViZXJuZXRlcwogIHNlcnZpY2VOZXR3b3JrOgogIC0gMTcyLjMwLjAuMC8xNgpwbGF0Zm9ybToKICBhenVyZToKICAgIGJhc2VEb21haW5SZXNvdXJjZUdyb3VwTmFtZTogZG9qby1kbnMtem9uZXMKICAgIHJlZ2lvbjogZWFzdHVzCnB1bGxTZWNyZXQ6ICIiICMgc2tpcCwgaGl2ZSB3aWxsIGluamVjdCBiYXNlZCBvbiBpdCdzIHNlY3JldHMKc3NoS2V5OiAiIiAgICAgIyBza2lwLCBoaXZlIHdpbGwgaW5qZWN0IGJhc2VkIG9uIGl0J3Mgc2VjcmV0cw== 
+  install-config.yaml: CgphcGlWZXJzaW9uOiB2MQptZXRhZGF0YToKICBuYW1lOiAnYXp1cmUtdXMnIApiYXNlRG9tYWluOiBibHVlcHJpbnRzLnJoZWNvZW5nLmNvbQpjb250cm9sUGxhbmU6CiAgYXJjaGl0ZWN0dXJlOiBhbWQ2NAogIGh5cGVydGhyZWFkaW5nOiBFbmFibGVkCiAgbmFtZTogY29udHJvbFBsYW5lCiAgcmVwbGljYXM6IDMKICBwbGF0Zm9ybToKICAgIGF6dXJlOgogICAgICB0eXBlOiBTdGFuZGFyZF9EOHNfdjMKY29tcHV0ZToKLSBoeXBlcnRocmVhZGluZzogRW5hYmxlZAogIGFyY2hpdGVjdHVyZTogYW1kNjQKICBuYW1lOiAnd29ya2VyJwogIHJlcGxpY2FzOiAzCiAgcGxhdGZvcm06CiAgICBhenVyZToKICAgICAgdHlwZTogU3RhbmRhcmRfRDhzX3YzCm5ldHdvcmtpbmc6CiAgY2x1c3Rlck5ldHdvcms6CiAgLSBjaWRyOiAxMC4xMjguMC4wLzE0CiAgICBob3N0UHJlZml4OiAyMwogIG1hY2hpbmVOZXR3b3JrOgogIC0gY2lkcjogMTAuMC4wLjAvMTYKICBuZXR3b3JrVHlwZTogT1ZOS3ViZXJuZXRlcwogIHNlcnZpY2VOZXR3b3JrOgogIC0gMTcyLjMwLjAuMC8xNgpwbGF0Zm9ybToKICBhenVyZToKICAgIGJhc2VEb21haW5SZXNvdXJjZUdyb3VwTmFtZTogZG9qby1kbnMtem9uZXMKICAgIHJlZ2lvbjogZWFzdHVzCnB1bGxTZWNyZXQ6ICIiICMgc2tpcCwgaGl2ZSB3aWxsIGluamVjdCBiYXNlZCBvbiBpdCdzIHNlY3JldHMKc3NoS2V5OiAiIiAgICAgIyBza2lwLCBoaXZlIHdpbGwgaW5qZWN0IGJhc2VkIG9uIGl0J3Mgc2VjcmV0cw==
 type: Opaque
 ---
 # Source: acm/templates/policies/acm-hub-ca-policy.yaml
@@ -79,7 +79,7 @@ spec:
   runningCount: 0
   baseDomain: blueprints.rhecoeng.com
   installConfigSecretTemplateRef:
-    name: aws-ap-acm-provision-edge-install-config 
+    name: aws-ap-acm-provision-edge-install-config
   imageSetRef:
     name: img4.10.18-multi-appsub
   pullSecretRef:
@@ -109,7 +109,7 @@ spec:
   runningCount: 2
   baseDomain: blueprints.rhecoeng.com
   installConfigSecretTemplateRef:
-    name: azure-us-acm-provision-edge-install-config 
+    name: azure-us-acm-provision-edge-install-config
   imageSetRef:
     name: img4.10.18-multi-appsub
   pullSecretRef:
@@ -147,7 +147,7 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: aws-ap-acm-provision-edge-infra-creds
-spec: 
+spec:
   data:
   - secretKey: openshiftPullSecret
     remoteRef:
@@ -170,7 +170,7 @@ spec:
       key: secret/data/hub/privatekey
       property: content
   refreshInterval: 24h0m0s
-  secretStoreRef: 
+  secretStoreRef:
     name: vault-backend
     kind: ClusterSecretStore
   target:
@@ -229,7 +229,7 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: azure-us-acm-provision-edge-infra-creds
-spec: 
+spec:
   data:
   - secretKey: openshiftPullSecret
     remoteRef:
@@ -248,7 +248,7 @@ spec:
       key: secret/data/hub/azureOsServicePrincipal
       property: content
   refreshInterval: 24h0m0s
-  secretStoreRef: 
+  secretStoreRef:
     name: vault-backend
     kind: ClusterSecretStore
   target:
@@ -282,7 +282,7 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: aws-ap-acm-provision-edge-pull-secret
-spec: 
+spec:
   data:
   - secretKey: openshiftPullSecret
     remoteRef:
@@ -330,7 +330,7 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: azure-us-acm-provision-edge-pull-secret
-spec: 
+spec:
   data:
   - secretKey: openshiftPullSecret
     remoteRef:
@@ -373,8 +373,8 @@ spec:
         ssh-privatekey: |-
           {{ .sshPrivateKey | toString }}
 ---
-# Source: acm/templates/provision/clusterpool.yaml
-apiVersion: cluster.open-cluster-management.io/v1beta1
+# Source: acm/templates/provision/managedclusterset.yaml
+apiVersion: cluster.open-cluster-management.io/v1beta2
 kind: ManagedClusterSet
 metadata:
   annotations:

--- a/tests/acm-normal.expected.yaml
+++ b/tests/acm-normal.expected.yaml
@@ -36,6 +36,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: aws-cd-one-w-pool-acm-provision-edge-install-config
+  namespace: aws-cd-one-w-pool-acm-provision-edge
 data:
   # Base64 encoding of install-config yaml
   install-config.yaml: CgphcGlWZXJzaW9uOiB2MQptZXRhZGF0YToKICBuYW1lOiAnYXdzLWNkLW9uZS13LXBvb2wnIApiYXNlRG9tYWluOiBibHVlcHJpbnRzLnJoZWNvZW5nLmNvbQpjb250cm9sUGxhbmU6CiAgYXJjaGl0ZWN0dXJlOiBhbWQ2NAogIGh5cGVydGhyZWFkaW5nOiBFbmFibGVkCiAgbmFtZTogY29udHJvbFBsYW5lCiAgcmVwbGljYXM6IDMKICBwbGF0Zm9ybToKICAgIGF3czoKICAgICAgdHlwZTogbTUueGxhcmdlCmNvbXB1dGU6Ci0gaHlwZXJ0aHJlYWRpbmc6IEVuYWJsZWQKICBhcmNoaXRlY3R1cmU6IGFtZDY0CiAgbmFtZTogJ3dvcmtlcicKICByZXBsaWNhczogMwogIHBsYXRmb3JtOgogICAgYXdzOgogICAgICB0eXBlOiBtNS54bGFyZ2UKbmV0d29ya2luZzoKICBjbHVzdGVyTmV0d29yazoKICAtIGNpZHI6IDEwLjEyOC4wLjAvMTQKICAgIGhvc3RQcmVmaXg6IDIzCiAgbWFjaGluZU5ldHdvcms6CiAgLSBjaWRyOiAxMC4wLjAuMC8xNgogIG5ldHdvcmtUeXBlOiBPVk5LdWJlcm5ldGVzCiAgc2VydmljZU5ldHdvcms6CiAgLSAxNzIuMzAuMC4wLzE2CnBsYXRmb3JtOgogIGF3czoKICAgIHJlZ2lvbjogYXAtc291dGhlYXN0LTEKcHVsbFNlY3JldDogIiIgIyBza2lwLCBoaXZlIHdpbGwgaW5qZWN0IGJhc2VkIG9uIGl0J3Mgc2VjcmV0cwpzc2hLZXk6ICIiICAgICAjIHNraXAsIGhpdmUgd2lsbCBpbmplY3QgYmFzZWQgb24gaXQncyBzZWNyZXRz
@@ -46,6 +47,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: aws-cd-two-wo-pool-acm-provision-on-deploy-install-config
+  namespace: aws-cd-two-wo-pool-acm-provision-on-deploy
 data:
   # Base64 encoding of install-config yaml
   install-config.yaml: CgphcGlWZXJzaW9uOiB2MQptZXRhZGF0YToKICBuYW1lOiAnYXdzLWNkLXR3by13by1wb29sJyAKYmFzZURvbWFpbjogYmx1ZXByaW50cy5yaGVjb2VuZy5jb20KY29udHJvbFBsYW5lOgogIGFyY2hpdGVjdHVyZTogYW1kNjQKICBoeXBlcnRocmVhZGluZzogRW5hYmxlZAogIG5hbWU6IGNvbnRyb2xQbGFuZQogIHJlcGxpY2FzOiAzCiAgcGxhdGZvcm06CiAgICBhd3M6CiAgICAgIHR5cGU6IG01LnhsYXJnZQpjb21wdXRlOgotIGh5cGVydGhyZWFkaW5nOiBFbmFibGVkCiAgYXJjaGl0ZWN0dXJlOiBhbWQ2NAogIG5hbWU6ICd3b3JrZXInCiAgcmVwbGljYXM6IDMKICBwbGF0Zm9ybToKICAgIGF3czoKICAgICAgdHlwZTogbTUueGxhcmdlCm5ldHdvcmtpbmc6CiAgY2x1c3Rlck5ldHdvcms6CiAgLSBjaWRyOiAxMC4xMjguMC4wLzE0CiAgICBob3N0UHJlZml4OiAyMwogIG1hY2hpbmVOZXR3b3JrOgogIC0gY2lkcjogMTAuMC4wLjAvMTYKICBuZXR3b3JrVHlwZTogT1ZOS3ViZXJuZXRlcwogIHNlcnZpY2VOZXR3b3JrOgogIC0gMTcyLjMwLjAuMC8xNgpwbGF0Zm9ybToKICBhd3M6CiAgICByZWdpb246IGFwLXNvdXRoZWFzdC0zCnB1bGxTZWNyZXQ6ICIiICMgc2tpcCwgaGl2ZSB3aWxsIGluamVjdCBiYXNlZCBvbiBpdCdzIHNlY3JldHMKc3NoS2V5OiAiIiAgICAgIyBza2lwLCBoaXZlIHdpbGwgaW5qZWN0IGJhc2VkIG9uIGl0J3Mgc2VjcmV0cw==
@@ -294,6 +296,7 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: aws-cd-one-w-pool-acm-provision-edge-creds
+  namespace: aws-cd-one-w-pool-acm-provision-edge
 spec:
   dataFrom:
   - extract:
@@ -315,6 +318,7 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: aws-cd-one-w-pool-acm-provision-edge-infra-creds
+  namespace: aws-cd-one-w-pool-acm-provision-edge
 spec:
   data:
   - secretKey: openshiftPullSecret
@@ -372,6 +376,7 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: aws-cd-two-wo-pool-acm-provision-on-deploy-creds
+  namespace: aws-cd-two-wo-pool-acm-provision-on-deploy
 spec:
   dataFrom:
   - extract:
@@ -393,6 +398,7 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: aws-cd-two-wo-pool-acm-provision-on-deploy-infra-creds
+  namespace: aws-cd-two-wo-pool-acm-provision-on-deploy
 spec:
   data:
   - secretKey: openshiftPullSecret
@@ -624,6 +630,7 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: aws-cd-one-w-pool-acm-provision-edge-pull-secret
+  namespace: aws-cd-one-w-pool-acm-provision-edge
 spec:
   data:
   - secretKey: openshiftPullSecret
@@ -648,6 +655,7 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: aws-cd-one-w-pool-acm-provision-edge-ssh-private-key
+  namespace: aws-cd-one-w-pool-acm-provision-edge
 spec:
   data:
   - secretKey: sshPrivateKey
@@ -672,6 +680,7 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: aws-cd-two-wo-pool-acm-provision-on-deploy-pull-secret
+  namespace: aws-cd-two-wo-pool-acm-provision-on-deploy
 spec:
   data:
   - secretKey: openshiftPullSecret
@@ -696,6 +705,7 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: aws-cd-two-wo-pool-acm-provision-on-deploy-ssh-private-key
+  namespace: aws-cd-two-wo-pool-acm-provision-on-deploy
 spec:
   data:
   - secretKey: sshPrivateKey

--- a/tests/acm-normal.expected.yaml
+++ b/tests/acm-normal.expected.yaml
@@ -101,6 +101,8 @@ metadata:
   namespace: aws-cd-one-w-pool-acm-provision-edge
   labels:
     vendor: OpenShift
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   baseDomain: blueprints.rhecoeng.com
   clusterName: aws-cd-one-w-pool-acm-provision-edge
@@ -128,6 +130,8 @@ metadata:
   namespace: aws-cd-two-wo-pool-acm-provision-on-deploy
   labels:
     vendor: OpenShift
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   baseDomain: blueprints.rhecoeng.com
   clusterName: aws-cd-two-wo-pool-acm-provision-on-deploy
@@ -719,6 +723,8 @@ metadata:
     cluster.open-cluster-management.io/clusterset: acm-provision-edge
     clusterGroup: region
   name: aws-cd-one-w-pool-acm-provision-edge
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   hubAcceptsClient: true
 ---
@@ -730,6 +736,8 @@ metadata:
     cluster.open-cluster-management.io/clusterset: acm-provision-on-deploy
     clusterGroup: acm-provision-on-deploy
   name: aws-cd-two-wo-pool-acm-provision-on-deploy
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   hubAcceptsClient: true
 ---

--- a/tests/acm-normal.expected.yaml
+++ b/tests/acm-normal.expected.yaml
@@ -749,9 +749,6 @@ metadata:
     cluster.open-cluster-management.io/submariner-broker-ns: acm-provision-edge-broker
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   name: acm-provision-edge
-spec:
-  clusterSelector:
-    selectorType: LegacyClusterSetLabel
 ---
 # Source: acm/templates/provision/managedclusterset.yaml
 apiVersion: cluster.open-cluster-management.io/v1beta2
@@ -761,9 +758,6 @@ metadata:
     cluster.open-cluster-management.io/submariner-broker-ns: acm-provision-on-deploy-broker
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   name: acm-provision-on-deploy
-spec:
-  clusterSelector:
-    selectorType: LegacyClusterSetLabel
 ---
 # Source: acm/templates/multiclusterhub.yaml
 apiVersion: operator.open-cluster-management.io/v1

--- a/tests/acm-normal.expected.yaml
+++ b/tests/acm-normal.expected.yaml
@@ -1,4 +1,16 @@
 ---
+# Source: acm/templates/provision/clusterdeployment.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: aws-cd-one-w-pool-acm-provision-edge
+---
+# Source: acm/templates/provision/clusterdeployment.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: aws-cd-two-wo-pool-acm-provision-on-deploy
+---
 # Source: acm/templates/provision/secrets-common.yaml
 apiVersion: v1
 kind: Secret
@@ -17,6 +29,26 @@ metadata:
 data:
   # Base64 encoding of install-config yaml
   install-config.yaml: CgphcGlWZXJzaW9uOiB2MQptZXRhZGF0YToKICBuYW1lOiAnYXp1cmUtdXMnIApiYXNlRG9tYWluOiBibHVlcHJpbnRzLnJoZWNvZW5nLmNvbQpjb250cm9sUGxhbmU6CiAgYXJjaGl0ZWN0dXJlOiBhbWQ2NAogIGh5cGVydGhyZWFkaW5nOiBFbmFibGVkCiAgbmFtZTogY29udHJvbFBsYW5lCiAgcmVwbGljYXM6IDMKICBwbGF0Zm9ybToKICAgIGF6dXJlOgogICAgICB0eXBlOiBTdGFuZGFyZF9EOHNfdjMKY29tcHV0ZToKLSBoeXBlcnRocmVhZGluZzogRW5hYmxlZAogIGFyY2hpdGVjdHVyZTogYW1kNjQKICBuYW1lOiAnd29ya2VyJwogIHJlcGxpY2FzOiAzCiAgcGxhdGZvcm06CiAgICBhenVyZToKICAgICAgdHlwZTogU3RhbmRhcmRfRDhzX3YzCm5ldHdvcmtpbmc6CiAgY2x1c3Rlck5ldHdvcms6CiAgLSBjaWRyOiAxMC4xMjguMC4wLzE0CiAgICBob3N0UHJlZml4OiAyMwogIG1hY2hpbmVOZXR3b3JrOgogIC0gY2lkcjogMTAuMC4wLjAvMTYKICBuZXR3b3JrVHlwZTogT1ZOS3ViZXJuZXRlcwogIHNlcnZpY2VOZXR3b3JrOgogIC0gMTcyLjMwLjAuMC8xNgpwbGF0Zm9ybToKICBhenVyZToKICAgIGJhc2VEb21haW5SZXNvdXJjZUdyb3VwTmFtZTogZG9qby1kbnMtem9uZXMKICAgIHJlZ2lvbjogZWFzdHVzCnB1bGxTZWNyZXQ6ICIiICMgc2tpcCwgaGl2ZSB3aWxsIGluamVjdCBiYXNlZCBvbiBpdCdzIHNlY3JldHMKc3NoS2V5OiAiIiAgICAgIyBza2lwLCBoaXZlIHdpbGwgaW5qZWN0IGJhc2VkIG9uIGl0J3Mgc2VjcmV0cw==
+type: Opaque
+---
+# Source: acm/templates/provision/secrets-common.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aws-cd-one-w-pool-acm-provision-edge-install-config
+data:
+  # Base64 encoding of install-config yaml
+  install-config.yaml: CgphcGlWZXJzaW9uOiB2MQptZXRhZGF0YToKICBuYW1lOiAnYXdzLWNkLW9uZS13LXBvb2wnIApiYXNlRG9tYWluOiBibHVlcHJpbnRzLnJoZWNvZW5nLmNvbQpjb250cm9sUGxhbmU6CiAgYXJjaGl0ZWN0dXJlOiBhbWQ2NAogIGh5cGVydGhyZWFkaW5nOiBFbmFibGVkCiAgbmFtZTogY29udHJvbFBsYW5lCiAgcmVwbGljYXM6IDMKICBwbGF0Zm9ybToKICAgIGF3czoKICAgICAgdHlwZTogbTUueGxhcmdlCmNvbXB1dGU6Ci0gaHlwZXJ0aHJlYWRpbmc6IEVuYWJsZWQKICBhcmNoaXRlY3R1cmU6IGFtZDY0CiAgbmFtZTogJ3dvcmtlcicKICByZXBsaWNhczogMwogIHBsYXRmb3JtOgogICAgYXdzOgogICAgICB0eXBlOiBtNS54bGFyZ2UKbmV0d29ya2luZzoKICBjbHVzdGVyTmV0d29yazoKICAtIGNpZHI6IDEwLjEyOC4wLjAvMTQKICAgIGhvc3RQcmVmaXg6IDIzCiAgbWFjaGluZU5ldHdvcms6CiAgLSBjaWRyOiAxMC4wLjAuMC8xNgogIG5ldHdvcmtUeXBlOiBPVk5LdWJlcm5ldGVzCiAgc2VydmljZU5ldHdvcms6CiAgLSAxNzIuMzAuMC4wLzE2CnBsYXRmb3JtOgogIGF3czoKICAgIHJlZ2lvbjogYXAtc291dGhlYXN0LTEKcHVsbFNlY3JldDogIiIgIyBza2lwLCBoaXZlIHdpbGwgaW5qZWN0IGJhc2VkIG9uIGl0J3Mgc2VjcmV0cwpzc2hLZXk6ICIiICAgICAjIHNraXAsIGhpdmUgd2lsbCBpbmplY3QgYmFzZWQgb24gaXQncyBzZWNyZXRz
+type: Opaque
+---
+# Source: acm/templates/provision/secrets-common.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aws-cd-two-wo-pool-acm-provision-on-deploy-install-config
+data:
+  # Base64 encoding of install-config yaml
+  install-config.yaml: CgphcGlWZXJzaW9uOiB2MQptZXRhZGF0YToKICBuYW1lOiAnYXdzLWNkLXR3by13by1wb29sJyAKYmFzZURvbWFpbjogYmx1ZXByaW50cy5yaGVjb2VuZy5jb20KY29udHJvbFBsYW5lOgogIGFyY2hpdGVjdHVyZTogYW1kNjQKICBoeXBlcnRocmVhZGluZzogRW5hYmxlZAogIG5hbWU6IGNvbnRyb2xQbGFuZQogIHJlcGxpY2FzOiAzCiAgcGxhdGZvcm06CiAgICBhd3M6CiAgICAgIHR5cGU6IG01LnhsYXJnZQpjb21wdXRlOgotIGh5cGVydGhyZWFkaW5nOiBFbmFibGVkCiAgYXJjaGl0ZWN0dXJlOiBhbWQ2NAogIG5hbWU6ICd3b3JrZXInCiAgcmVwbGljYXM6IDMKICBwbGF0Zm9ybToKICAgIGF3czoKICAgICAgdHlwZTogbTUueGxhcmdlCm5ldHdvcmtpbmc6CiAgY2x1c3Rlck5ldHdvcms6CiAgLSBjaWRyOiAxMC4xMjguMC4wLzE0CiAgICBob3N0UHJlZml4OiAyMwogIG1hY2hpbmVOZXR3b3JrOgogIC0gY2lkcjogMTAuMC4wLjAvMTYKICBuZXR3b3JrVHlwZTogT1ZOS3ViZXJuZXRlcwogIHNlcnZpY2VOZXR3b3JrOgogIC0gMTcyLjMwLjAuMC8xNgpwbGF0Zm9ybToKICBhd3M6CiAgICByZWdpb246IGFwLXNvdXRoZWFzdC0zCnB1bGxTZWNyZXQ6ICIiICMgc2tpcCwgaGl2ZSB3aWxsIGluamVjdCBiYXNlZCBvbiBpdCdzIHNlY3JldHMKc3NoS2V5OiAiIiAgICAgIyBza2lwLCBoaXZlIHdpbGwgaW5qZWN0IGJhc2VkIG9uIGl0J3Mgc2VjcmV0cw==
 type: Opaque
 ---
 # Source: acm/templates/policies/acm-hub-ca-policy.yaml
@@ -60,6 +92,60 @@ metadata:
     clusterGroup: region
 spec:
   clusterPoolName: azure-us-acm-provision-edge
+---
+# Source: acm/templates/provision/clusterdeployment.yaml
+apiVersion: hive.openshift.io/v1
+kind: ClusterDeployment
+metadata:
+  name: aws-cd-one-w-pool-acm-provision-edge
+  namespace: aws-cd-one-w-pool-acm-provision-edge
+  labels:
+    vendor: OpenShift
+spec:
+  baseDomain: blueprints.rhecoeng.com
+  clusterName: aws-cd-one-w-pool-acm-provision-edge
+  installAttemptsLimit: 1
+  platform:
+    aws:
+      credentialsSecretRef:
+        name: aws-cd-one-w-pool-acm-provision-edge-creds
+      region: ap-southeast-1
+  provisioning:
+    installConfigSecretRef:
+      name: aws-cd-one-w-pool-acm-provision-edge-install-config
+    sshPrivateKeySecretRef:
+      name: aws-cd-one-w-pool-acm-provision-edge-ssh-private-key
+    imageSetRef:
+      name: img4.10.18-multi-appsub
+  pullSecretRef:
+    name: aws-cd-one-w-pool-acm-provision-edge-pull-secret
+---
+# Source: acm/templates/provision/clusterdeployment.yaml
+apiVersion: hive.openshift.io/v1
+kind: ClusterDeployment
+metadata:
+  name: aws-cd-two-wo-pool-acm-provision-on-deploy
+  namespace: aws-cd-two-wo-pool-acm-provision-on-deploy
+  labels:
+    vendor: OpenShift
+spec:
+  baseDomain: blueprints.rhecoeng.com
+  clusterName: aws-cd-two-wo-pool-acm-provision-on-deploy
+  installAttemptsLimit: 1
+  platform:
+    aws:
+      credentialsSecretRef:
+        name: aws-cd-two-wo-pool-acm-provision-on-deploy-creds
+      region: ap-southeast-3
+  provisioning:
+    installConfigSecretRef:
+      name: aws-cd-two-wo-pool-acm-provision-on-deploy-install-config
+    sshPrivateKeySecretRef:
+      name: aws-cd-two-wo-pool-acm-provision-on-deploy-ssh-private-key
+    imageSetRef:
+      name: img4.10.18-multi-appsub
+  pullSecretRef:
+    name: aws-cd-two-wo-pool-acm-provision-on-deploy-pull-secret
 ---
 # Source: acm/templates/provision/clusterpool.yaml
 apiVersion: hive.openshift.io/v1
@@ -175,6 +261,162 @@ spec:
     kind: ClusterSecretStore
   target:
     name: aws-ap-acm-provision-edge-infra-creds
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      metadata:
+        labels:
+          cluster.open-cluster-management.io/credentials: ""
+          cluster.open-cluster-management.io/type: aws
+      data:
+        baseDomain: "blueprints.rhecoeng.com"
+        pullSecret: |-
+          {{ .openshiftPullSecret | toString }}
+        aws_access_key_id: |-
+          {{ .awsKeyId | toString }}
+        aws_secret_access_key: |-
+          {{ .awsAccessKey | toString }}
+        ssh-privatekey: |-
+          {{ .sshPrivateKey | toString }}
+        ssh-publickey: |-
+          {{ .sshPublicKey | toString }}
+        httpProxy: ""
+        httpsProxy: ""
+        noProxy: ""
+        additionalTrustBundle: ""
+---
+# Source: acm/templates/provision/secrets-aws.yaml
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: aws-cd-one-w-pool-acm-provision-edge-creds
+spec:
+  dataFrom:
+  - extract:
+      # Expects entries called: aws_access_key_id and aws_secret_access_key
+      key: secret/data/hub/aws
+  refreshInterval: 24h0m0s
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: aws-cd-one-w-pool-acm-provision-edge-creds
+    creationPolicy: Owner
+    template:
+      type: Opaque
+---
+# Source: acm/templates/provision/secrets-aws.yaml
+# For use when manually creating clusters with ACM
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: aws-cd-one-w-pool-acm-provision-edge-infra-creds
+spec:
+  data:
+  - secretKey: openshiftPullSecret
+    remoteRef:
+      key: secret/data/hub/openshiftPullSecret
+      property: content
+  - secretKey: awsKeyId
+    remoteRef:
+      key: secret/data/hub/aws
+      property: aws_access_key_id
+  - secretKey: awsAccessKey
+    remoteRef:
+      key: secret/data/hub/aws
+      property: aws_secret_access_key
+  - secretKey: sshPublicKey
+    remoteRef:
+      key: secret/data/hub/publickey
+      property: content
+  - secretKey: sshPrivateKey
+    remoteRef:
+      key: secret/data/hub/privatekey
+      property: content
+  refreshInterval: 24h0m0s
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: aws-cd-one-w-pool-acm-provision-edge-infra-creds
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      metadata:
+        labels:
+          cluster.open-cluster-management.io/credentials: ""
+          cluster.open-cluster-management.io/type: aws
+      data:
+        baseDomain: "blueprints.rhecoeng.com"
+        pullSecret: |-
+          {{ .openshiftPullSecret | toString }}
+        aws_access_key_id: |-
+          {{ .awsKeyId | toString }}
+        aws_secret_access_key: |-
+          {{ .awsAccessKey | toString }}
+        ssh-privatekey: |-
+          {{ .sshPrivateKey | toString }}
+        ssh-publickey: |-
+          {{ .sshPublicKey | toString }}
+        httpProxy: ""
+        httpsProxy: ""
+        noProxy: ""
+        additionalTrustBundle: ""
+---
+# Source: acm/templates/provision/secrets-aws.yaml
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: aws-cd-two-wo-pool-acm-provision-on-deploy-creds
+spec:
+  dataFrom:
+  - extract:
+      # Expects entries called: aws_access_key_id and aws_secret_access_key
+      key: secret/data/hub/aws
+  refreshInterval: 24h0m0s
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: aws-cd-two-wo-pool-acm-provision-on-deploy-creds
+    creationPolicy: Owner
+    template:
+      type: Opaque
+---
+# Source: acm/templates/provision/secrets-aws.yaml
+# For use when manually creating clusters with ACM
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: aws-cd-two-wo-pool-acm-provision-on-deploy-infra-creds
+spec:
+  data:
+  - secretKey: openshiftPullSecret
+    remoteRef:
+      key: secret/data/hub/openshiftPullSecret
+      property: content
+  - secretKey: awsKeyId
+    remoteRef:
+      key: secret/data/hub/aws
+      property: aws_access_key_id
+  - secretKey: awsAccessKey
+    remoteRef:
+      key: secret/data/hub/aws
+      property: aws_secret_access_key
+  - secretKey: sshPublicKey
+    remoteRef:
+      key: secret/data/hub/publickey
+      property: content
+  - secretKey: sshPrivateKey
+    remoteRef:
+      key: secret/data/hub/privatekey
+      property: content
+  refreshInterval: 24h0m0s
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: aws-cd-two-wo-pool-acm-provision-on-deploy-infra-creds
     creationPolicy: Owner
     template:
       type: Opaque
@@ -373,6 +615,124 @@ spec:
         ssh-privatekey: |-
           {{ .sshPrivateKey | toString }}
 ---
+# Source: acm/templates/provision/secrets-common.yaml
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: aws-cd-one-w-pool-acm-provision-edge-pull-secret
+spec:
+  data:
+  - secretKey: openshiftPullSecret
+    remoteRef:
+      key: secret/data/hub/openshiftPullSecret
+      property: content
+  refreshInterval: 24h0m0s
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: aws-cd-one-w-pool-acm-provision-edge-pull-secret
+    creationPolicy: Owner
+    template:
+      type: kubernetes.io/dockerconfigjson
+      data:
+        .dockerconfigjson: |-
+          {{ .openshiftPullSecret | toString }}
+---
+# Source: acm/templates/provision/secrets-common.yaml
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: aws-cd-one-w-pool-acm-provision-edge-ssh-private-key
+spec:
+  data:
+  - secretKey: sshPrivateKey
+    remoteRef:
+      key: secret/data/hub/privatekey
+      property: content
+  refreshInterval: 24h0m0s
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: aws-cd-one-w-pool-acm-provision-edge-ssh-private-key
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      data:
+        ssh-privatekey: |-
+          {{ .sshPrivateKey | toString }}
+---
+# Source: acm/templates/provision/secrets-common.yaml
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: aws-cd-two-wo-pool-acm-provision-on-deploy-pull-secret
+spec:
+  data:
+  - secretKey: openshiftPullSecret
+    remoteRef:
+      key: secret/data/hub/openshiftPullSecret
+      property: content
+  refreshInterval: 24h0m0s
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: aws-cd-two-wo-pool-acm-provision-on-deploy-pull-secret
+    creationPolicy: Owner
+    template:
+      type: kubernetes.io/dockerconfigjson
+      data:
+        .dockerconfigjson: |-
+          {{ .openshiftPullSecret | toString }}
+---
+# Source: acm/templates/provision/secrets-common.yaml
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: aws-cd-two-wo-pool-acm-provision-on-deploy-ssh-private-key
+spec:
+  data:
+  - secretKey: sshPrivateKey
+    remoteRef:
+      key: secret/data/hub/privatekey
+      property: content
+  refreshInterval: 24h0m0s
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: aws-cd-two-wo-pool-acm-provision-on-deploy-ssh-private-key
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      data:
+        ssh-privatekey: |-
+          {{ .sshPrivateKey | toString }}
+---
+# Source: acm/templates/provision/clusterdeployment.yaml
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  labels:
+    cluster.open-cluster-management.io/clusterset: acm-provision-edge
+    clusterGroup: region
+  name: aws-cd-one-w-pool-acm-provision-edge
+spec:
+  hubAcceptsClient: true
+---
+# Source: acm/templates/provision/clusterdeployment.yaml
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  labels:
+    cluster.open-cluster-management.io/clusterset: acm-provision-on-deploy
+    clusterGroup: acm-provision-on-deploy
+  name: aws-cd-two-wo-pool-acm-provision-on-deploy
+spec:
+  hubAcceptsClient: true
+---
 # Source: acm/templates/provision/managedclusterset.yaml
 apiVersion: cluster.open-cluster-management.io/v1beta2
 kind: ManagedClusterSet
@@ -381,6 +741,18 @@ metadata:
     cluster.open-cluster-management.io/submariner-broker-ns: acm-provision-edge-broker
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   name: acm-provision-edge
+spec:
+  clusterSelector:
+    selectorType: LegacyClusterSetLabel
+---
+# Source: acm/templates/provision/managedclusterset.yaml
+apiVersion: cluster.open-cluster-management.io/v1beta2
+kind: ManagedClusterSet
+metadata:
+  annotations:
+    cluster.open-cluster-management.io/submariner-broker-ns: acm-provision-on-deploy-broker
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  name: acm-provision-on-deploy
 spec:
   clusterSelector:
     selectorType: LegacyClusterSetLabel
@@ -441,6 +813,22 @@ placementRef:
   apiGroup: apps.open-cluster-management.io
 subjects:
   - name: acm-provision-edge-clustergroup-policy
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
+---
+# Source: acm/templates/policies/application-policies.yaml
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: acm-provision-on-deploy-placement-binding
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+placementRef:
+  name: acm-provision-on-deploy-placement
+  kind: PlacementRule
+  apiGroup: apps.open-cluster-management.io
+subjects:
+  - name: acm-provision-on-deploy-clustergroup-policy
     kind: Policy
     apiGroup: policy.open-cluster-management.io
 ---
@@ -507,6 +895,21 @@ spec:
   clusterSelector:
     matchLabels:
       clusterGroup: region
+---
+# Source: acm/templates/policies/application-policies.yaml
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: acm-provision-on-deploy-placement
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  clusterConditions:
+    - status: 'True'
+      type: ManagedClusterConditionAvailable
+  clusterSelector:
+    matchLabels:
+      clusterGroup: acm-provision-on-deploy
 ---
 # Source: acm/templates/policies/ocp-gitops-policy.yaml
 apiVersion: apps.open-cluster-management.io/v1
@@ -747,6 +1150,102 @@ spec:
                   destination:
                     server: https://kubernetes.default.svc
                     namespace: mypattern-acm-provision-edge
+                  syncPolicy:
+                    automated:
+                      prune: false
+                      selfHeal: true
+                    retry:
+                      limit: 20
+                  ignoreDifferences:
+                  - group: apps
+                    kind: Deployment
+                    jsonPointers:
+                    - /spec/replicas
+                  - group: route.openshift.io
+                    kind: Route
+                    jsonPointers:
+                    - /status
+---
+# Source: acm/templates/policies/application-policies.yaml
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: acm-provision-on-deploy-clustergroup-policy
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
+spec:
+  remediationAction: enforce
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: acm-provision-on-deploy-clustergroup-config
+        spec:
+          remediationAction: enforce
+          severity: medium
+          namespaceSelector:
+            include:
+              - default
+          object-templates:
+            - complianceType: mustonlyhave
+              objectDefinition:
+                apiVersion: argoproj.io/v1alpha1
+                kind: Application
+                metadata:
+                  name: mypattern-acm-provision-on-deploy
+                  namespace: openshift-gitops
+                  finalizers:
+                  - resources-finalizer.argocd.argoproj.io/foreground
+                spec:
+                  project: default
+                  source:
+                    repoURL: https://github.com/pattern-clone/mypattern
+                    targetRevision: main
+                    path: common/clustergroup
+                    helm:
+                      ignoreMissingValueFiles: true
+                      valueFiles:
+                        - "/values-global.yaml"
+                        - "/values-acm-provision-on-deploy.yaml"
+                        - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}.yaml'
+                        - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}-{{ printf "%d.%d" ((semver (index (lookup "config.openshift.io/v1" "ClusterVersion" "" "version").status.history 0).version).Major) ((semver (index (lookup "config.openshift.io/v1" "ClusterVersion" "" "version").status.history 0).version).Minor) }}.yaml'
+                        - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}-acm-provision-on-deploy.yaml'
+                        # We cannot use $.Values.global.clusterVersion because that gets resolved to the
+                        # hub's cluster version, whereas we want to include the spoke cluster version
+                        - '/values-{{ printf "%d.%d" ((semver (index (lookup "config.openshift.io/v1" "ClusterVersion" "" "version").status.history 0).version).Major) ((semver (index (lookup "config.openshift.io/v1" "ClusterVersion" "" "version").status.history 0).version).Minor) }}.yaml'
+                      parameters:
+                      - name: global.repoURL
+                        value: https://github.com/pattern-clone/mypattern
+                      - name: global.targetRevision
+                        value: main
+                      - name: global.namespace
+                        value: $ARGOCD_APP_NAMESPACE
+                      - name: global.pattern
+                        value: mypattern
+                      - name: global.hubClusterDomain
+                        value: apps.hub.example.com
+                      - name: global.localClusterDomain
+                        value: '{{ (lookup "config.openshift.io/v1" "Ingress" "" "cluster").spec.domain }}'
+                      # Requires ACM 2.6 or higher
+                      - name: global.clusterDomain
+                        value: '{{ (lookup "config.openshift.io/v1" "Ingress" "" "cluster").spec.domain | replace "apps." "" }}'
+                      # Requires ACM 2.6 or higher (I could not come up with something less terrible to get maj.min)
+                      - name: global.clusterVersion
+                        value: '{{ printf "%d.%d" ((semver (index (lookup "config.openshift.io/v1" "ClusterVersion" "" "version").status.history 0).version).Major) ((semver (index (lookup "config.openshift.io/v1" "ClusterVersion" "" "version").status.history 0).version).Minor) }}'
+                      - name: global.localClusterName
+                        value: '{{ (split "." (lookup "config.openshift.io/v1" "Ingress" "" "cluster").spec.domain)._1 }}'
+                      - name: global.clusterPlatform
+                        value: aws
+                      - name: clusterGroup.name
+                        value: acm-provision-on-deploy
+                      - name: global.experimentalCapabilities
+                        value: 
+                  destination:
+                    server: https://kubernetes.default.svc
+                    namespace: mypattern-acm-provision-on-deploy
                   syncPolicy:
                     automated:
                       prune: false

--- a/tests/clustergroup-normal.expected.yaml
+++ b/tests/clustergroup-normal.expected.yaml
@@ -160,6 +160,14 @@ data:
       - acmlabels:
         - name: clusterGroup
           value: region
+        clusterDeployments:
+          myFirstCluster:
+            baseDomain: blueprints.rhecoeng.com
+            name: aws-cd-one-w-pool
+            openshiftVersion: 4.10.18
+            platform:
+              aws:
+                region: ap-southeast-1
         clusterPools:
           exampleAWSPool:
             baseDomain: blueprints.rhecoeng.com
@@ -192,6 +200,15 @@ data:
           value: "false"
         name: acm-provision-edge
         targetRevision: main
+      - clusterDeployments:
+          mySecondCluster:
+            baseDomain: blueprints.rhecoeng.com
+            name: aws-cd-two-wo-pool
+            openshiftVersion: 4.10.18
+            platform:
+              aws:
+                region: ap-southeast-3
+        name: acm-provision-on-deploy
       - helmOverrides:
         - name: clusterGroup.isHubCluster
           value: "false"


### PR DESCRIPTION
- Added feature for creating Spoke Clusters using Hive's [ClusterDeployment API](https://github.com/openshift/hive/blob/master/docs/using-hive.md#clusterdeployment).
- Modified the _clustergroup_ schema; added `clusterDeployments` for a group, used `clusterPools` as a template.
- Modified test cases testing `clusterDeployments` on the same _multiclustergroup_ with `clusterPools` and on its own.
- Multiple Commits in this PR make reviewing easier; these can be squashed together if required.
- If preferred, we can move the tests to a different PR to make this smaller.

Example configuration:
```yaml
  managedClusterGroups:
    - name: group-with-pool
      clusterPools:
        spokesPool:
          name: spokes-pool
          openshiftVersion: 4.14.12
          baseDomain: domain.example.com
          platform:
            aws:
              region: ap-southeast-2
          clusters:
          - spoke1
          - spoke2

    - name: group-with-deployments
      clusterDeployments:
        myFirstCustomSpoke:
          name: my-first-custom-spoke
          openshiftVersion: 4.14.12
          baseDomain: domain.example.com
          platform:
            azure:
              baseDomainResourceGroupName: dojo-dns-zones
              region: eastus
        mySecondCustomSpoke:
          name: my-second-custom-spoke
          openshiftVersion: 4.14.12
          baseDomain: domain.example.ca
          platform:
            azure:
              baseDomainResourceGroupName: dojo-dns-zones
              region: westca

    # all clusters in the following group, claims or deployments, are considered part of the same
    # group, same labeling mechanism, shared managed cluster set, etc.
    - name: group-with-both
      clusterPools:
        anotherSpokesPool:
          name: another-spokes-pool
          openshiftVersion: 4.14.12
          baseDomain: domain.example.com
          platform:
            aws:
              region: ap-southwest-1
          clusters:
            - another-spoke1
      clusterDeployments:
        anotherCustomSpoke:
          name: another-custom-spoke
          openshiftVersion: 4.14.12
          baseDomain: domain.example.com
          platform:
            aws:
              region: ap-southwest-3

```

