### PR TITLE
Support remote repoURL when previewing templates

### DIFF
--- a/scripts/preview.sh
+++ b/scripts/preview.sh
@@ -96,6 +96,10 @@ done
 
 if [ $isKustomize == "true" ]; then
     kustomizePath=$(yq ".clusterGroup.applications.$APP.path" values-$SITE.yaml)
+    repoURL=$(yq ".clusterGroup.applications.$APP.repoURL" values-$SITE.yaml)
+    if [[ $repoURL == http* ]] || [[ $repoURL == git@ ]]; then
+         kustomizePath="${repoURL}/${kustomizePath}"
+    fi
     cmd="oc kustomize ${kustomizePath}"
     eval "$cmd"
 else


### PR DESCRIPTION
This allows us to have a remote repoURL + path kustomize combo and show
the resulting templates in `make preview`.

Tested with:

    web-terminal:
      name: web-terminal
      namespace: hello-world
      project: hub
      kustomize: true
      targetRevision: main
      repoURL: https://github.com/redhat-cop/gitops-catalog
      path: web-terminal/aggregate/overlays/default

Closes: https://github.com/validatedpatterns/multicloud-gitops/issues/356
