### PR TITLE
Moved CLUSTERGROUP declaration to restore make preview-% functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 NAME ?= $(shell basename "`pwd`")
+CLUSTERGROUP ?= $(shell yq ".main.clusterGroupName" values-global.yaml)
+
 ifneq ($(origin TARGET_SITE), undefined)
   TARGET_SITE_OPT=--set main.clusterGroupName=$(TARGET_SITE)
 endif
@@ -60,7 +62,6 @@ preview-all: ## (EXPERIMENTAL) Previews all applications on hub and managed clus
 	@common/scripts/preview-all.sh $(TARGET_REPO) $(TARGET_BRANCH)
 
 preview-%:
-	CLUSTERGROUP?=$(shell yq ".main.clusterGroupName" values-global.yaml)
 	@common/scripts/preview.sh $(CLUSTERGROUP) $* $(TARGET_REPO) $(TARGET_BRANCH)
 
 .PHONY: operator-deploy


### PR DESCRIPTION
Attempts to 

`source pattern.sh make preview-{myapp}`

currently fail without this change in place, 