### PR TITLE
bug: Fixes indenting and duplicate entries in application-policies.yaml

### DIFF
--- a/acm/templates/policies/application-policies.yaml
+++ b/acm/templates/policies/application-policies.yaml
@@ -44,11 +44,8 @@ spec:
                     helm:
                       ignoreMissingValueFiles: true
                       valueFiles:
-                      {{- include "acm.app.policies.valuefiles" . | nindent 24 }}
+                      {{- include "acm.app.policies.valuefiles" . | nindent 22 }}
                       {{- range $valueFile := $.Values.global.extraValueFiles }}
-                      - {{ $valueFile | quote }}
-                      {{- end }}
-                      {{- range $valueFile := .extraValueFiles }}
                       - {{ $valueFile | quote }}
                       {{- end }}
                       parameters:


### PR DESCRIPTION
This corrects Argo error:
Failed to load target state: failed to generate manifest for source 1 of 1: rpc error: code = Unknown desc = Manifest generation error (cached): `helm template . --name-template acm --namespace open-cluster-management --kube-version 1.25 --set global.privateRepo=false --set global.experimentalCapabilities=initcontainers --set global.repoURL=https://github.myrepo.com/EnterpriseKubernetes/multicloud-gitops.git --set global.clusterDomain=mydomain.azure.us --set global.clusterPlatform=Azure --set global.hubClusterDomain=mydomain.azure.us --set global.localClusterDomain=mydomain.azure.us --set global.targetRevision=prod --set global.namespace=open-cluster-management --set global.pattern=ekho --set global.clusterVersion=4.12 --values <path to cached source>/values-global.yaml --values <path to cached source>/values-hub.yaml <api versions removed> --include-crds` failed exit status 1: Error: YAML parse error on acm/templates/policies/application-policies.yaml: error converting YAML to JSON: yaml: line 50: did not find expected key Use --debug flag to render out invalid YAML

Also corrects mapping error warning on make preview-acm