### PR TITLE
Use --recurse-submodules when cloning

### DIFF
--- a/clustergroup/templates/imperative/_helpers.tpl
+++ b/clustergroup/templates/imperative/_helpers.tpl
@@ -65,7 +65,7 @@
     OUT="$(oc get proxy.config.openshift.io/cluster -o jsonpath='{.spec.noProxy}' 2>/dev/null)";
     if [ -n "${OUT}" ]; then export NO_PROXY="${OUT}"; fi;
     mkdir /git/{repo,home};
-    git clone --single-branch --branch {{ $.Values.global.targetRevision }} --depth 1 -- "${URL}" /git/repo;
+    git clone --recurse-submodules --single-branch --branch {{ $.Values.global.targetRevision }} --depth 1 -- "${URL}" /git/repo;
     chmod 0770 /git/{repo,home};
 {{- end }}
 
@@ -109,7 +109,7 @@
     OUT="$(oc get proxy.config.openshift.io/cluster -o jsonpath='{.spec.noProxy}' 2>/dev/null)";
     if [ -n "${OUT}" ]; then export NO_PROXY="${OUT}"; fi;
     mkdir /git/{repo,home};
-    git clone --single-branch --branch {{ $.Values.global.targetRevision }} --depth 1 -- "${URL}" /git/repo;
+    git clone --recurse-submodules --single-branch --branch {{ $.Values.global.targetRevision }} --depth 1 -- "${URL}" /git/repo;
     chmod 0770 /git/{repo,home};
 {{- end }}
 {{/* Final done container */}}

--- a/tests/clustergroup-industrial-edge-factory.expected.yaml
+++ b/tests/clustergroup-industrial-edge-factory.expected.yaml
@@ -408,7 +408,7 @@ spec:
                 OUT="$(oc get proxy.config.openshift.io/cluster -o jsonpath='{.spec.noProxy}' 2>/dev/null)";
                 if [ -n "${OUT}" ]; then export NO_PROXY="${OUT}"; fi;
                 mkdir /git/{repo,home};
-                git clone --single-branch --branch main --depth 1 -- "${URL}" /git/repo;
+                git clone --recurse-submodules --single-branch --branch main --depth 1 -- "${URL}" /git/repo;
                 chmod 0770 /git/{repo,home};
             - name: test
               image: registry.redhat.io/ansible-automation-platform-24/ee-supported-rhel9:latest

--- a/tests/clustergroup-industrial-edge-hub.expected.yaml
+++ b/tests/clustergroup-industrial-edge-hub.expected.yaml
@@ -569,7 +569,7 @@ spec:
                 OUT="$(oc get proxy.config.openshift.io/cluster -o jsonpath='{.spec.noProxy}' 2>/dev/null)";
                 if [ -n "${OUT}" ]; then export NO_PROXY="${OUT}"; fi;
                 mkdir /git/{repo,home};
-                git clone --single-branch --branch main --depth 1 -- "${URL}" /git/repo;
+                git clone --recurse-submodules --single-branch --branch main --depth 1 -- "${URL}" /git/repo;
                 chmod 0770 /git/{repo,home};
             - name: test
               image: registry.redhat.io/ansible-automation-platform-24/ee-supported-rhel9:latest
@@ -668,7 +668,7 @@ spec:
                 OUT="$(oc get proxy.config.openshift.io/cluster -o jsonpath='{.spec.noProxy}' 2>/dev/null)";
                 if [ -n "${OUT}" ]; then export NO_PROXY="${OUT}"; fi;
                 mkdir /git/{repo,home};
-                git clone --single-branch --branch main --depth 1 -- "${URL}" /git/repo;
+                git clone --recurse-submodules --single-branch --branch main --depth 1 -- "${URL}" /git/repo;
                 chmod 0770 /git/{repo,home};
             - name: unseal-playbook
               image: registry.redhat.io/ansible-automation-platform-24/ee-supported-rhel9:latest

--- a/tests/clustergroup-medical-diagnosis-hub.expected.yaml
+++ b/tests/clustergroup-medical-diagnosis-hub.expected.yaml
@@ -496,7 +496,7 @@ spec:
                 OUT="$(oc get proxy.config.openshift.io/cluster -o jsonpath='{.spec.noProxy}' 2>/dev/null)";
                 if [ -n "${OUT}" ]; then export NO_PROXY="${OUT}"; fi;
                 mkdir /git/{repo,home};
-                git clone --single-branch --branch main --depth 1 -- "${URL}" /git/repo;
+                git clone --recurse-submodules --single-branch --branch main --depth 1 -- "${URL}" /git/repo;
                 chmod 0770 /git/{repo,home};
             - name: test
               image: registry.redhat.io/ansible-automation-platform-24/ee-supported-rhel9:latest
@@ -595,7 +595,7 @@ spec:
                 OUT="$(oc get proxy.config.openshift.io/cluster -o jsonpath='{.spec.noProxy}' 2>/dev/null)";
                 if [ -n "${OUT}" ]; then export NO_PROXY="${OUT}"; fi;
                 mkdir /git/{repo,home};
-                git clone --single-branch --branch main --depth 1 -- "${URL}" /git/repo;
+                git clone --recurse-submodules --single-branch --branch main --depth 1 -- "${URL}" /git/repo;
                 chmod 0770 /git/{repo,home};
             - name: unseal-playbook
               image: registry.redhat.io/ansible-automation-platform-24/ee-supported-rhel9:latest

--- a/tests/clustergroup-naked.expected.yaml
+++ b/tests/clustergroup-naked.expected.yaml
@@ -261,7 +261,7 @@ spec:
                 OUT="$(oc get proxy.config.openshift.io/cluster -o jsonpath='{.spec.noProxy}' 2>/dev/null)";
                 if [ -n "${OUT}" ]; then export NO_PROXY="${OUT}"; fi;
                 mkdir /git/{repo,home};
-                git clone --single-branch --branch main --depth 1 -- "${URL}" /git/repo;
+                git clone --recurse-submodules --single-branch --branch main --depth 1 -- "${URL}" /git/repo;
                 chmod 0770 /git/{repo,home};
             - name: unseal-playbook
               image: registry.redhat.io/ansible-automation-platform-24/ee-supported-rhel9:latest

--- a/tests/clustergroup-normal.expected.yaml
+++ b/tests/clustergroup-normal.expected.yaml
@@ -458,7 +458,7 @@ spec:
                 OUT="$(oc get proxy.config.openshift.io/cluster -o jsonpath='{.spec.noProxy}' 2>/dev/null)";
                 if [ -n "${OUT}" ]; then export NO_PROXY="${OUT}"; fi;
                 mkdir /git/{repo,home};
-                git clone --single-branch --branch main --depth 1 -- "${URL}" /git/repo;
+                git clone --recurse-submodules --single-branch --branch main --depth 1 -- "${URL}" /git/repo;
                 chmod 0770 /git/{repo,home};
             - name: test
               image: registry.redhat.io/ansible-automation-platform-24/ee-supported-rhel9:latest
@@ -557,7 +557,7 @@ spec:
                 OUT="$(oc get proxy.config.openshift.io/cluster -o jsonpath='{.spec.noProxy}' 2>/dev/null)";
                 if [ -n "${OUT}" ]; then export NO_PROXY="${OUT}"; fi;
                 mkdir /git/{repo,home};
-                git clone --single-branch --branch main --depth 1 -- "${URL}" /git/repo;
+                git clone --recurse-submodules --single-branch --branch main --depth 1 -- "${URL}" /git/repo;
                 chmod 0770 /git/{repo,home};
             - name: unseal-playbook
               image: registry.redhat.io/ansible-automation-platform-24/ee-supported-rhel9:latest


### PR DESCRIPTION
In case a git repo has some things split over submodules, let's clone
those too.

The version of git in the imperative image is currently:
sh-5.1# git version
git version 2.39.3

Tested with:
sh-5.1# git clone --recurse-submodules --single-branch --branch main --depth 1 -- "https://github.com/validatedpatterns/multicloud-gitops" /tmp/
Cloning into '/tmp'...
remote: Enumerating objects: 426, done.
remote: Counting objects: 100% (426/426), done.
remote: Compressing objects: 100% (343/343), done.
remote: Total 426 (delta 87), reused 221 (delta 40), pack-reused 0
Receiving objects: 100% (426/426), 545.98 KiB | 1.78 MiB/s, done.
Resolving deltas: 100% (87/87), done.

Co-Authored-By: Sergio Garcia Martinez <sgarcia@redhat.com>
