### PR TITLE
New global scope argocdServer section for values-global.yaml

### DIFF
--- a/acm/templates/policies/ocp-gitops-policy.yaml
+++ b/acm/templates/policies/ocp-gitops-policy.yaml
@@ -195,6 +195,11 @@ spec:
                         memory: 128Mi
                     route:
                       enabled: true
+                      {{- if and (.Values.global.argocdServer) (.Values.global.argocdServer.route) (.Values.global.argocdServer.route.tls) }}
+                      tls:
+                        insecureEdgeTerminationPolicy: {{ default "Redirect" .Values.global.argocdServer.route.tls.insecureEdgeTerminationPolicy }}
+                        termination: {{ default "reencrypt" .Values.global.argocdServer.route.tls.termination }}
+                      {{- end }}
                     service:
                       type: ""
                   sso:


### PR DESCRIPTION
- Added new section for to configure the ArgoCD server to support tls
```
global:
  argocdServer:
    route:
      tls:
        insecureEdgeTerminationPolicy: Redirect
        termination: reencrypt
```
- Default for ArgoCD is to create route with the following:
```
      route: enabled
      tls:
        insecureEdgeTerminationPolicy: Redirect
        termination: passthrough
```

    For more information please refer to https://issues.redhat.com/browse/GITOPS-3918.
