### PR TITLE
Drop gitopsspec from pattern's CR

### DIFF
--- a/operator-install/templates/pattern.yaml
+++ b/operator-install/templates/pattern.yaml
@@ -12,9 +12,6 @@ spec:
     tokenSecret: {{ .Values.main.tokenSecret }}
     tokenSecretNamespace: {{ .Values.main.tokenSecretNamespace }}
 {{- end }} {{/* if and .Values.main.tokenSecret .Values.main.tokenSecretNamespace */}}
-  gitOpsSpec:
-    operatorChannel: {{ default "gitops-1.12" .Values.main.gitops.channel }}
-    operatorSource: {{ default "redhat-operators" .Values.main.gitops.operatorSource }}
   multiSourceConfig:
     enabled: {{ .Values.main.multiSourceConfig.enabled }}
 {{- if .Values.main.analyticsUUID }}

--- a/tests/operator-install-industrial-edge-factory.expected.yaml
+++ b/tests/operator-install-industrial-edge-factory.expected.yaml
@@ -25,9 +25,6 @@ spec:
   gitSpec:
     targetRepo: https://github.com/pattern-clone/mypattern
     targetRevision: main 
-  gitOpsSpec:
-    operatorChannel: gitops-1.12
-    operatorSource: redhat-operators
   multiSourceConfig:
     enabled: false
 ---

--- a/tests/operator-install-industrial-edge-hub.expected.yaml
+++ b/tests/operator-install-industrial-edge-hub.expected.yaml
@@ -25,9 +25,6 @@ spec:
   gitSpec:
     targetRepo: https://github.com/pattern-clone/mypattern
     targetRevision: main 
-  gitOpsSpec:
-    operatorChannel: gitops-1.12
-    operatorSource: redhat-operators
   multiSourceConfig:
     enabled: false
 ---

--- a/tests/operator-install-medical-diagnosis-hub.expected.yaml
+++ b/tests/operator-install-medical-diagnosis-hub.expected.yaml
@@ -25,9 +25,6 @@ spec:
   gitSpec:
     targetRepo: https://github.com/pattern-clone/mypattern
     targetRevision: main 
-  gitOpsSpec:
-    operatorChannel: gitops-1.12
-    operatorSource: redhat-operators
   multiSourceConfig:
     enabled: false
 ---

--- a/tests/operator-install-naked.expected.yaml
+++ b/tests/operator-install-naked.expected.yaml
@@ -25,9 +25,6 @@ spec:
   gitSpec:
     targetRepo: https://github.com/pattern-clone/mypattern
     targetRevision: main 
-  gitOpsSpec:
-    operatorChannel: gitops-1.12
-    operatorSource: redhat-operators
   multiSourceConfig:
     enabled: false
 ---

--- a/tests/operator-install-normal.expected.yaml
+++ b/tests/operator-install-normal.expected.yaml
@@ -25,9 +25,6 @@ spec:
   gitSpec:
     targetRepo: https://github.com/pattern-clone/mypattern
     targetRevision: main 
-  gitOpsSpec:
-    operatorChannel: gitops-1.12
-    operatorSource: redhat-operators
   multiSourceConfig:
     enabled: false
 ---


### PR DESCRIPTION
We drive this from the patterns-operator-config configmap these days, which
makes more sense (it is a clusterwide setting and not really a per
pattern one).
