### PR TITLE
Allow customizing the VP operator subscription

### DIFF
--- a/operator-install/templates/subscription.yaml
+++ b/operator-install/templates/subscription.yaml
@@ -7,7 +7,10 @@ metadata:
     operators.coreos.com/patterns-operator.openshift-operators: ""
 spec:
   channel: {{ .Values.main.patternsOperator.channel }}
-  installPlanApproval: Automatic
+  installPlanApproval: {{ .Values.main.patternsOperator.installPlanApproval }}
   name: patterns-operator
   source: {{ .Values.main.patternsOperator.source }}
-  sourceNamespace: openshift-marketplace
+  sourceNamespace: {{ .Values.main.patternsOperator.sourceNamespace }}
+  {{- if .Values.main.patternsOperator.startingCSV }}
+  startingCSV: {{ .Values.main.patternsOperator.startingCSV }}
+  {{- end }}

--- a/operator-install/values.yaml
+++ b/operator-install/values.yaml
@@ -20,6 +20,9 @@ main:
   patternsOperator:
     channel: fast
     source: community-operators
+    installPlanApproval: Automatic
+    sourceNamespace: openshift-marketplace
+    startingCSV: null
 
   clusterGroupName: default
 


### PR DESCRIPTION
Tested with:

❯ helm template operator-install --show-only templates/subscription.yaml --set main.patternsOperator.installPlanApproval=Manual

    ---
    apiVersion: operators.coreos.com/v1alpha1
    kind: Subscription
    metadata:
      name: patterns-operator
      namespace: openshift-operators
      labels:
        operators.coreos.com/patterns-operator.openshift-operators: ""
    spec:
      channel: fast
      installPlanApproval: Manual
      name: patterns-operator
      source: community-operators
      sourceNamespace: openshift-marketplace

❯ helm template operator-install --show-only templates/subscription.yaml --set main.patternsOperator.installPlanApproval=Manual --set main.patternsOperator.startingCSV=1.2.3

    ---
    apiVersion: operators.coreos.com/v1alpha1
    kind: Subscription
    metadata:
      name: patterns-operator
      namespace: openshift-operators
      labels:
        operators.coreos.com/patterns-operator.openshift-operators: ""
    spec:
      channel: fast
      installPlanApproval: Manual
      name: patterns-operator
      source: community-operators
      sourceNamespace: openshift-marketplace
      startingCSV: 1.2.3
