### PR TITLE
Added support to enable user workloads in control plane nodes

### DIFF
--- a/clustergroup/templates/core/scheduler.yaml
+++ b/clustergroup/templates/core/scheduler.yaml
@@ -1,0 +1,8 @@
+{{- if not (eq .Values.enabled "plumbing") }}
+apiVersion: config.openshift.io/v1
+kind: Scheduler
+metadata:
+  name: cluster
+spec:
+  mastersSchedulable: {{ $.Values.clusterGroup.mastersSchedulable }}
+{{- end -}}

--- a/clustergroup/values.schema.json
+++ b/clustergroup/values.schema.json
@@ -257,6 +257,10 @@
             "type": "array",
             "description": "Templated value file paths."
 	},
+        "mastersSchedulable": {
+          "type": "boolean",
+          "description": "if set to true, the control plane nodes will be marked as schedulable for user workloads also."
+        },
         "namespaces": {
           "anyOf": [
             {

--- a/clustergroup/values.yaml
+++ b/clustergroup/values.yaml
@@ -20,6 +20,8 @@ clusterGroup:
   targetCluster: in-cluster
   sharedValueFiles: []
 
+  mastersSchedulable: false
+
   argoCD:
     initContainers: []
     configManagementPlugins: []

--- a/examples/values-example.yaml
+++ b/examples/values-example.yaml
@@ -15,6 +15,8 @@ clusterGroup:
   - /values/{{ .Values.global.clusterPlatform }}.yaml
   - /values/{{ .Values.global.clusterVersion }}.yaml
 
+  mastersSchedulable: true
+
   # 
   # You can define namespaces using hashes and not as a list like so:
   # namespaces:

--- a/tests/clustergroup-industrial-edge-factory.expected.yaml
+++ b/tests/clustergroup-industrial-edge-factory.expected.yaml
@@ -146,6 +146,7 @@ data:
         verbosity: ""
       isHubCluster: false
       managedClusterGroups: {}
+      mastersSchedulable: false
       name: factory
       namespaces:
       - manuela-stormshift-line-dashboard
@@ -773,6 +774,14 @@ metadata:
 spec:
   targetNamespaces:
   - manuela-stormshift-messaging
+---
+# Source: clustergroup/templates/core/scheduler.yaml
+apiVersion: config.openshift.io/v1
+kind: Scheduler
+metadata:
+  name: cluster
+spec:
+  mastersSchedulable: false
 ---
 # Source: clustergroup/templates/core/subscriptions.yaml
 apiVersion: operators.coreos.com/v1alpha1

--- a/tests/clustergroup-industrial-edge-hub.expected.yaml
+++ b/tests/clustergroup-industrial-edge-hub.expected.yaml
@@ -280,6 +280,7 @@ data:
           - name: clusterGroup.isHubCluster
             value: "false"
           name: factory
+      mastersSchedulable: false
       name: datacenter
       namespaces:
       - golang-external-secrets
@@ -1546,6 +1547,14 @@ metadata:
 spec:
   targetNamespaces:
   - vault
+---
+# Source: clustergroup/templates/core/scheduler.yaml
+apiVersion: config.openshift.io/v1
+kind: Scheduler
+metadata:
+  name: cluster
+spec:
+  mastersSchedulable: false
 ---
 # Source: clustergroup/templates/core/subscriptions.yaml
 apiVersion: operators.coreos.com/v1alpha1

--- a/tests/clustergroup-medical-diagnosis-hub.expected.yaml
+++ b/tests/clustergroup-medical-diagnosis-hub.expected.yaml
@@ -259,6 +259,7 @@ data:
           - name: clusterGroup.isHubCluster
             value: false
           name: region-one
+      mastersSchedulable: false
       name: hub
       namespaces:
       - open-cluster-management
@@ -1704,6 +1705,14 @@ metadata:
 spec:
   targetNamespaces:
   - golang-external-secrets
+---
+# Source: clustergroup/templates/core/scheduler.yaml
+apiVersion: config.openshift.io/v1
+kind: Scheduler
+metadata:
+  name: cluster
+spec:
+  mastersSchedulable: false
 ---
 # Source: clustergroup/templates/core/subscriptions.yaml
 apiVersion: operators.coreos.com/v1alpha1

--- a/tests/clustergroup-naked.expected.yaml
+++ b/tests/clustergroup-naked.expected.yaml
@@ -71,6 +71,7 @@ data:
         verbosity: ""
       isHubCluster: true
       managedClusterGroups: {}
+      mastersSchedulable: false
       name: example
       namespaces: []
       projects: []
@@ -463,3 +464,11 @@ spec:
   href: 'https://example-gitops-server-common-example.'
   location: ApplicationMenu
   text: 'Example ArgoCD'
+---
+# Source: clustergroup/templates/core/scheduler.yaml
+apiVersion: config.openshift.io/v1
+kind: Scheduler
+metadata:
+  name: cluster
+spec:
+  mastersSchedulable: false

--- a/tests/clustergroup-normal.expected.yaml
+++ b/tests/clustergroup-normal.expected.yaml
@@ -211,6 +211,7 @@ data:
         - domain: syd.beekhof.net
           name: sydney
         name: argo-edge
+      mastersSchedulable: true
       name: example
       namespaces:
       - open-cluster-management:
@@ -1216,6 +1217,14 @@ metadata:
 spec:
   targetNamespaces:
   - include-default-og
+---
+# Source: clustergroup/templates/core/scheduler.yaml
+apiVersion: config.openshift.io/v1
+kind: Scheduler
+metadata:
+  name: cluster
+spec:
+  mastersSchedulable: true
 ---
 # Source: clustergroup/templates/core/subscriptions.yaml
 apiVersion: operators.coreos.com/v1alpha1


### PR DESCRIPTION
Simple PR to allow setting control planes schedulables without extra charts.