### PR TITLE
Switch to registry.redhat.io for the initContainer image

### DIFF
--- a/acm/templates/policies/ocp-gitops-policy.yaml
+++ b/acm/templates/policies/ocp-gitops-policy.yaml
@@ -140,7 +140,7 @@ spec:
                       - -c
                       - cat /var/run/kube-root-ca/ca.crt /var/run/trusted-ca/ca-bundle.crt > /tmp/ca-bundles/ca-bundle.crt
                         || true
-                      image: registry.access.redhat.com/ubi9/ubi-minimal:latest
+                      image: registry.redhat.io/ubi9/ubi-minimal:latest
                       name: fetch-ca
                       resources: {}
                       volumeMounts:


### PR DESCRIPTION
This makes the registry url more consistent with what we already use
(e.g. in the imperative templates)
