### PR TITLE
Update for ACM chart to application-policies.yaml

### DIFF
--- a/acm/templates/policies/application-policies.yaml
+++ b/acm/templates/policies/application-policies.yaml
@@ -45,7 +45,7 @@ spec:
                       ignoreMissingValueFiles: true
                       valueFiles:
                       {{- include "acm.app.policies.valuefiles" . | nindent 22 }}
-                      {{- range $valueFile := $.Values.global.extraValueFiles }}
+                      {{- range $valueFile := .extraValueFiles }}
                       - {{ $valueFile | quote }}
                       {{- end }}
                       parameters:


### PR DESCRIPTION
- If statement was checking for .Values.global.extraValueFiles.
- We now checking at the .extraValueFiles in the managedClusterGroups section.

  managedClusterGroups:
    aro-prod:
      name: innovation
      acmlabels:
        - name: clusterGroup
          value: innovation
      extraValueFiles:
        - '/overrides/values-common-capabilities.yaml'
      helmOverrides:
        - name: clusterGroup.isHubCluster
          value: "false"
