### PR TITLE
Add extraParameters to values.schema.json

### DIFF
--- a/clustergroup/values.schema.json
+++ b/clustergroup/values.schema.json
@@ -65,6 +65,10 @@
         "clusterGroupName": {
           "type": "string"
         },
+        "extraParameters": {
+          "type": "array",
+          "description": "Pass in extra Helm parameters to all ArgoCD Applications and the framework."
+        },
         "experimentalCapabilities": {
           "type": "string",
           "description": "String to enable certain experimental capabilities in the operator and the framework."


### PR DESCRIPTION
- Problem Statement
  The current **clustergroup** schema does not allow the definition of **extraParameters** under the **main** section of a values file.

- Caveat
  The user defined variables in the **extraParameters** section would only be applied if the user deploys the pattern via the command, using `./pattern.sh make install` or `./pattern.sh make operator-deploy` and not via the OpenShift Validated Patterns Operator UI.

- Fix Description
  Add the **extraParameters** to the definition of **Main.properties** in the values.schema.json:

        "extraParameters": {
          "type": "array",
          "description": "Pass in extra Helm parameters to all ArgoCD Applications and the framework."
        },

- This will allow users to define extra parameters that will be added by the framework to the ArgoCD applications it creates.

- For more information see https://github.com/validatedpatterns/common/issues/510
