### PR TITLE
WIP: Additional namespace object definition for ACM Policy

### DIFF
--- a/acm/templates/policies/acm-hub-ca-policy.yaml
+++ b/acm/templates/policies/acm-hub-ca-policy.yaml
@@ -24,6 +24,12 @@ spec:
             include:
               - default
           object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                kind: Namespace # must have namespace 'imperative'
+                apiVersion: v1
+                metadata:
+                  name: imperative
             - complianceType: mustonlyhave
               objectDefinition:
                 kind: Secret

--- a/tests/acm-industrial-edge-hub.expected.yaml
+++ b/tests/acm-industrial-edge-hub.expected.yaml
@@ -160,6 +160,12 @@ spec:
             include:
               - default
           object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                kind: Namespace # must have namespace 'imperative'
+                apiVersion: v1
+                metadata:
+                  name: imperative
             - complianceType: mustonlyhave
               objectDefinition:
                 kind: Secret

--- a/tests/acm-medical-diagnosis-hub.expected.yaml
+++ b/tests/acm-medical-diagnosis-hub.expected.yaml
@@ -151,6 +151,12 @@ spec:
             include:
               - default
           object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                kind: Namespace # must have namespace 'imperative'
+                apiVersion: v1
+                metadata:
+                  name: imperative
             - complianceType: mustonlyhave
               objectDefinition:
                 kind: Secret

--- a/tests/acm-normal.expected.yaml
+++ b/tests/acm-normal.expected.yaml
@@ -554,6 +554,12 @@ spec:
             include:
               - default
           object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                kind: Namespace # must have namespace 'imperative'
+                apiVersion: v1
+                metadata:
+                  name: imperative
             - complianceType: mustonlyhave
               objectDefinition:
                 kind: Secret


### PR DESCRIPTION
- In some environments we have noticed that in some instances the imperative namespace does not get created on
  Spoke clusters.
- The policy in common/acm/templates/policies/acm-hub-ca-policy creates a Secret in the imperative namespace which
  might fail if the namespace does not exist.
- Adding new objectDefinition to the current ACM policy to create the 'imperative' namespace.
- Updated CI Tests with new ACM Policy
