### PR TITLE
Feat: Followup to definition of extraParameters under the main section of a values file.

### DIFF
--- a/acm/templates/policies/application-policies.yaml
+++ b/acm/templates/policies/application-policies.yaml
@@ -43,6 +43,11 @@ spec:
                     path: {{ default "common/clustergroup" .path }}
                     helm:
                       ignoreMissingValueFiles: true
+                      values: |
+                        extraParametersNested:
+                        {{- range $k, $v := $.Values.extraParametersNested }}
+                          {{ $k }}: {{ printf "%s" $v | quote }}
+                        {{- end }}
                       valueFiles:
                       {{- include "acm.app.policies.valuefiles" . | nindent 22 }}
                       {{- range $valueFile := .extraValueFiles }}
@@ -73,6 +78,10 @@ spec:
                         value: {{ $group.name }}
                       - name: global.experimentalCapabilities
                         value: {{ $.Values.global.experimentalCapabilities }}
+                      {{- range $k, $v := $.Values.extraParametersNested }}
+                      - name: {{ $k }}
+                        value: {{ printf "%s" $v | quote }}
+                      {{- end }}
                      {{- range .helmOverrides }}
                       - name: {{ .name }}
                         value: {{ .value | quote }}

--- a/clustergroup/templates/plumbing/applications.yaml
+++ b/clustergroup/templates/plumbing/applications.yaml
@@ -149,6 +149,11 @@ spec:
       {{- else }}
       helm:
         ignoreMissingValueFiles: true
+        values: |
+          extraParametersNested: 
+          {{- range $k, $v := $.Values.extraParametersNested }}
+            {{ $k }}: {{ printf "%s" $v | quote }}
+          {{- end }}
         valueFiles:
         {{- include "clustergroup.app.globalvalues.prefixedvaluefiles" $ | nindent 8 }}
         {{- range $valueFile := $.Values.clusterGroup.sharedValueFiles }}
@@ -216,6 +221,11 @@ spec:
     {{- else if not .kustomize }}
     helm:
       ignoreMissingValueFiles: true
+      values: |
+        extraParametersNested:
+          {{- range $k, $v := $.Values.extraParametersNested }}
+            {{ $k }}: {{ printf "%s" $v | quote }}
+          {{- end }}
       valueFiles:
       {{- include "clustergroup.app.globalvalues.valuefiles" $ | nindent 6 }}
       {{- range $valueFile := $.Values.clusterGroup.sharedValueFiles }}

--- a/tests/acm-industrial-edge-hub.expected.yaml
+++ b/tests/acm-industrial-edge-hub.expected.yaml
@@ -214,6 +214,8 @@ spec:
                     path: common/clustergroup
                     helm:
                       ignoreMissingValueFiles: true
+                      values: |
+                        extraParametersNested:
                       valueFiles:
                       - "/values-global.yaml"
                       - "/values-factory.yaml"

--- a/tests/acm-medical-diagnosis-hub.expected.yaml
+++ b/tests/acm-medical-diagnosis-hub.expected.yaml
@@ -205,6 +205,8 @@ spec:
                     path: common/clustergroup
                     helm:
                       ignoreMissingValueFiles: true
+                      values: |
+                        extraParametersNested:
                       valueFiles:
                       - "/values-global.yaml"
                       - "/values-region-one.yaml"

--- a/tests/acm-normal.expected.yaml
+++ b/tests/acm-normal.expected.yaml
@@ -608,6 +608,8 @@ spec:
                     path: common/clustergroup
                     helm:
                       ignoreMissingValueFiles: true
+                      values: |
+                        extraParametersNested:
                       valueFiles:
                       - "/values-global.yaml"
                       - "/values-acm-edge.yaml"
@@ -704,6 +706,8 @@ spec:
                     path: common/clustergroup
                     helm:
                       ignoreMissingValueFiles: true
+                      values: |
+                        extraParametersNested:
                       valueFiles:
                       - "/values-global.yaml"
                       - "/values-acm-provision-edge.yaml"

--- a/tests/clustergroup-industrial-edge-factory.expected.yaml
+++ b/tests/clustergroup-industrial-edge-factory.expected.yaml
@@ -559,6 +559,8 @@ spec:
     path: charts/datacenter/opendatahub
     helm:
       ignoreMissingValueFiles: true
+      values: |
+        extraParametersNested:
       valueFiles:
       - "/values-global.yaml"
       - "/values-factory.yaml"

--- a/tests/clustergroup-industrial-edge-hub.expected.yaml
+++ b/tests/clustergroup-industrial-edge-hub.expected.yaml
@@ -857,6 +857,8 @@ spec:
     path: common/acm
     helm:
       ignoreMissingValueFiles: true
+      values: |
+        extraParametersNested:
       valueFiles:
       - "/values-global.yaml"
       - "/values-datacenter.yaml"
@@ -922,6 +924,8 @@ spec:
     path: charts/datacenter/opendatahub
     helm:
       ignoreMissingValueFiles: true
+      values: |
+        extraParametersNested:
       valueFiles:
       - "/values-global.yaml"
       - "/values-datacenter.yaml"
@@ -978,6 +982,8 @@ spec:
     path: charts/datacenter/pipelines
     helm:
       ignoreMissingValueFiles: true
+      values: |
+        extraParametersNested:
       valueFiles:
       - "/values-global.yaml"
       - "/values-datacenter.yaml"
@@ -1034,6 +1040,8 @@ spec:
     path: charts/datacenter/manuela-data-lake
     helm:
       ignoreMissingValueFiles: true
+      values: |
+        extraParametersNested:
       valueFiles:
       - "/values-global.yaml"
       - "/values-datacenter.yaml"
@@ -1120,6 +1128,8 @@ spec:
     path: charts/datacenter/external-secrets
     helm:
       ignoreMissingValueFiles: true
+      values: |
+        extraParametersNested:
       valueFiles:
       - "/values-global.yaml"
       - "/values-datacenter.yaml"
@@ -1176,6 +1186,8 @@ spec:
     path: common/golang-external-secrets
     helm:
       ignoreMissingValueFiles: true
+      values: |
+        extraParametersNested:
       valueFiles:
       - "/values-global.yaml"
       - "/values-datacenter.yaml"
@@ -1259,6 +1271,8 @@ spec:
     chart: vault
     helm:
       ignoreMissingValueFiles: true
+      values: |
+        extraParametersNested:
       valueFiles:
       - "/values-global.yaml"
       - "/values-datacenter.yaml"

--- a/tests/clustergroup-medical-diagnosis-hub.expected.yaml
+++ b/tests/clustergroup-medical-diagnosis-hub.expected.yaml
@@ -742,6 +742,8 @@ spec:
     path: common/golang-external-secrets
     helm:
       ignoreMissingValueFiles: true
+      values: |
+        extraParametersNested:
       valueFiles:
       - "/values-global.yaml"
       - "/values-hub.yaml"
@@ -798,6 +800,8 @@ spec:
     path: charts/all/kafdrop
     helm:
       ignoreMissingValueFiles: true
+      values: |
+        extraParametersNested:
       valueFiles:
       - "/values-global.yaml"
       - "/values-hub.yaml"
@@ -854,6 +858,8 @@ spec:
     path: charts/all/kafka
     helm:
       ignoreMissingValueFiles: true
+      values: |
+        extraParametersNested:
       valueFiles:
       - "/values-global.yaml"
       - "/values-hub.yaml"
@@ -910,6 +916,8 @@ spec:
     path: charts/all/opendatahub
     helm:
       ignoreMissingValueFiles: true
+      values: |
+        extraParametersNested:
       valueFiles:
       - "/values-global.yaml"
       - "/values-hub.yaml"
@@ -966,6 +974,8 @@ spec:
     path: charts/all/openshift-data-foundations
     helm:
       ignoreMissingValueFiles: true
+      values: |
+        extraParametersNested:
       valueFiles:
       - "/values-global.yaml"
       - "/values-hub.yaml"
@@ -1022,6 +1032,8 @@ spec:
     path: charts/all/openshift-serverless
     helm:
       ignoreMissingValueFiles: true
+      values: |
+        extraParametersNested:
       valueFiles:
       - "/values-global.yaml"
       - "/values-hub.yaml"
@@ -1078,6 +1090,8 @@ spec:
     path: charts/all/medical-diagnosis/service-account
     helm:
       ignoreMissingValueFiles: true
+      values: |
+        extraParametersNested:
       valueFiles:
       - "/values-global.yaml"
       - "/values-hub.yaml"
@@ -1134,6 +1148,8 @@ spec:
     chart: vault
     helm:
       ignoreMissingValueFiles: true
+      values: |
+        extraParametersNested:
       valueFiles:
       - "/values-global.yaml"
       - "/values-hub.yaml"
@@ -1208,6 +1224,8 @@ spec:
     path: charts/all/medical-diagnosis/database
     helm:
       ignoreMissingValueFiles: true
+      values: |
+        extraParametersNested:
       valueFiles:
       - "/values-global.yaml"
       - "/values-hub.yaml"
@@ -1264,6 +1282,8 @@ spec:
     path: charts/all/medical-diagnosis/grafana
     helm:
       ignoreMissingValueFiles: true
+      values: |
+        extraParametersNested:
       valueFiles:
       - "/values-global.yaml"
       - "/values-hub.yaml"
@@ -1320,6 +1340,8 @@ spec:
     path: charts/all/medical-diagnosis/image-generator
     helm:
       ignoreMissingValueFiles: true
+      values: |
+        extraParametersNested:
       valueFiles:
       - "/values-global.yaml"
       - "/values-hub.yaml"
@@ -1385,6 +1407,8 @@ spec:
     path: charts/all/medical-diagnosis/image-server
     helm:
       ignoreMissingValueFiles: true
+      values: |
+        extraParametersNested:
       valueFiles:
       - "/values-global.yaml"
       - "/values-hub.yaml"
@@ -1450,6 +1474,8 @@ spec:
     path: charts/all/medical-diagnosis/xray-init
     helm:
       ignoreMissingValueFiles: true
+      values: |
+        extraParametersNested:
       valueFiles:
       - "/values-global.yaml"
       - "/values-hub.yaml"

--- a/tests/clustergroup-normal.expected.yaml
+++ b/tests/clustergroup-normal.expected.yaml
@@ -707,6 +707,8 @@ spec:
     path: common/acm
     helm:
       ignoreMissingValueFiles: true
+      values: |
+        extraParametersNested:
       valueFiles:
       - "/values-global.yaml"
       - "/values-example.yaml"
@@ -774,6 +776,8 @@ spec:
     path: charts/datacenter/pipelines
     helm:
       ignoreMissingValueFiles: true
+      values: |
+        extraParametersNested:
       valueFiles:
       - "/values-global.yaml"
       - "/values-example.yaml"


### PR DESCRIPTION
- The operator adds these extraParameters to the extraParametersNested section as key/value pairs in the Cluster Wide ArgoCD Application created by the Validated Patterns operator.
- This update will add the user defined extra parameters on the ArgoCD Applications on the Spoke Clusters.
