### PR TITLE
Updates to acm-hub-ca

### DIFF
--- a/acm/templates/policies/acm-hub-ca-policy.yaml
+++ b/acm/templates/policies/acm-hub-ca-policy.yaml
@@ -1,5 +1,6 @@
 # This pushes out the HUB's Certificate Authorities on to the imported clusters
-{{ if .Values.clusterGroup.isHubCluster }}
+{{- if .Values.clusterGroup.isHubCluster }}
+{{- if (eq (((.Values.global).secretStore).backend) "vault") }}
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
@@ -67,5 +68,5 @@ spec:
         operator: NotIn
         values:
           - 'true'
-{{ end }}
-
+{{- end }}
+{{- end }}

--- a/acm/templates/policies/acm-hub-ca-policy.yaml
+++ b/acm/templates/policies/acm-hub-ca-policy.yaml
@@ -31,7 +31,7 @@ spec:
                 type: Opaque
                 metadata:
                   name: hub-ca
-                  namespace: imperative
+                  namespace: golang-external-secrets
                 data:
                   hub-kube-root-ca.crt: '{{ `{{hub fromConfigMap "" "kube-root-ca.crt" "ca.crt" | base64enc hub}}` }}'
                   hub-openshift-service-ca.crt: '{{ `{{hub fromConfigMap "" "openshift-service-ca.crt" "service-ca.crt" | base64enc hub}}` }}'

--- a/acm/values.yaml
+++ b/acm/values.yaml
@@ -9,6 +9,8 @@ global:
   targetRevision: main
   options:
     applicationRetryLimit: 20
+  secretStore:
+    backend: "vault"
 
 clusterGroup:
   subscriptions:

--- a/golang-external-secrets/values.yaml
+++ b/golang-external-secrets/values.yaml
@@ -23,7 +23,7 @@ golangExternalSecrets:
       type: Secret
       name: hub-ca
       key: hub-kube-root-ca.crt
-      namespace: imperative
+      namespace: golang-external-secrets
 
 global:
   hubClusterDomain: hub.example.com

--- a/tests/acm-industrial-edge-hub.expected.yaml
+++ b/tests/acm-industrial-edge-hub.expected.yaml
@@ -167,7 +167,7 @@ spec:
                 type: Opaque
                 metadata:
                   name: hub-ca
-                  namespace: imperative
+                  namespace: golang-external-secrets
                 data:
                   hub-kube-root-ca.crt: '{{hub fromConfigMap "" "kube-root-ca.crt" "ca.crt" | base64enc hub}}'
                   hub-openshift-service-ca.crt: '{{hub fromConfigMap "" "openshift-service-ca.crt" "service-ca.crt" | base64enc hub}}'

--- a/tests/acm-medical-diagnosis-hub.expected.yaml
+++ b/tests/acm-medical-diagnosis-hub.expected.yaml
@@ -158,7 +158,7 @@ spec:
                 type: Opaque
                 metadata:
                   name: hub-ca
-                  namespace: imperative
+                  namespace: golang-external-secrets
                 data:
                   hub-kube-root-ca.crt: '{{hub fromConfigMap "" "kube-root-ca.crt" "ca.crt" | base64enc hub}}'
                   hub-openshift-service-ca.crt: '{{hub fromConfigMap "" "openshift-service-ca.crt" "service-ca.crt" | base64enc hub}}'

--- a/tests/acm-normal.expected.yaml
+++ b/tests/acm-normal.expected.yaml
@@ -561,7 +561,7 @@ spec:
                 type: Opaque
                 metadata:
                   name: hub-ca
-                  namespace: imperative
+                  namespace: golang-external-secrets
                 data:
                   hub-kube-root-ca.crt: '{{hub fromConfigMap "" "kube-root-ca.crt" "ca.crt" | base64enc hub}}'
                   hub-openshift-service-ca.crt: '{{hub fromConfigMap "" "openshift-service-ca.crt" "service-ca.crt" | base64enc hub}}'

--- a/tests/golang-external-secrets-industrial-edge-factory.expected.yaml
+++ b/tests/golang-external-secrets-industrial-edge-factory.expected.yaml
@@ -12502,7 +12502,7 @@ spec:
         type: Secret
         name: hub-ca
         key: hub-kube-root-ca.crt
-        namespace: imperative
+        namespace: golang-external-secrets
 
       auth:
         kubernetes:


### PR DESCRIPTION
- **Use golang-external-secrets for the acm hub-ca bits**
- **Only do the acm hub ca policy when vault is the backend**
