### PR TITLE
bug: Invalid OperatorGroup generated when omitting targetNamespaces

### DIFF
--- a/clustergroup/templates/_helpers.tpl
+++ b/clustergroup/templates/_helpers.tpl
@@ -202,13 +202,19 @@ kind: OperatorGroup
 metadata:
   name: {{ $k }}-operator-group
   namespace: {{ $k }}
+      {{- if (hasKey $v "targetNamespaces") }}
+        {{- if $v.targetNamespaces }}
+          {{- if (len $v.targetNamespaces) }}
 spec:
   targetNamespaces:
-      {{- if (hasKey $v "targetNamespaces") }}
-        {{- range $v.targetNamespaces }}{{- /* We loop through the list of tergetnamespaces */}}
+            {{- range $v.targetNamespaces }}{{- /* We loop through the list of tergetnamespaces */}}
   - {{ . }}
-        {{- end }}{{- /* End range targetNamespaces */}}
+            {{- end }}{{- /* End range targetNamespaces */}}
+          {{- end }}{{- /* End if (len $v.targetNamespaces) */}}
+        {{- end }}{{- /* End $v.targetNamespaces */}}
       {{- else }}
+spec:
+  targetNamespaces:
   - {{ $k }}
       {{- end }}{{- /* End of if hasKey $v "targetNamespaces" */}}
     {{- end }}{{- /* End if $v.operatorGroup */}}

--- a/clustergroup/templates/core/operatorgroup.yaml
+++ b/clustergroup/templates/core/operatorgroup.yaml
@@ -21,15 +21,19 @@ kind: OperatorGroup
 metadata:
   name: {{ $k }}-operator-group
   namespace: {{ $k }}
+  {{- if (hasKey $v "targetNamespaces") }}
+    {{- if $v.targetNamespaces }}
 spec:
   targetNamespaces:
-    {{- if (hasKey $v "targetNamespaces") }}
       {{- range $v.targetNamespaces }}{{- /* We loop through the list of tergetnamespaces */}}
   - {{ . }}
       {{- end }}{{- /* End range targetNamespaces */}}
-    {{- else }}
+    {{- end }}{{- /* End if $v.targetNamespaces */}}
+  {{- else }}
+spec:
+  targetNamespaces:
   - {{ $k }}
-    {{- end }}{{- /* End of if operatorGroup */}}
+  {{- end }}{{- /* End of if (hasKey $v "targetNamespaces") */}}
   {{- end }}{{- /* range $k, $v := $ns */}}
   {{- end }}{{- /* End of if operatorGroup */}}
   {{- else if kindIs "string" $ns }}

--- a/clustergroup/templates/plumbing/applications.yaml
+++ b/clustergroup/templates/plumbing/applications.yaml
@@ -78,7 +78,7 @@ spec:
             - name: global.namespace
               value: {{ $.Values.global.namespace }}
             - name: clusterGroup.name
-              value: {{ .Values.clusterGroup.name }}
+              value: {{ $.Values.clusterGroup.name }}
         {{- range .extraHubClusterDomainFields }}
             - name: {{ . }}
               value: {{ $.Values.global.hubClusterDomain }}

--- a/tests/clustergroup-normal.expected.yaml
+++ b/tests/clustergroup-normal.expected.yaml
@@ -1197,8 +1197,6 @@ kind: OperatorGroup
 metadata:
   name: exclude-targetns-operator-group
   namespace: exclude-targetns
-spec:
-  targetNamespaces:
 ---
 # Source: clustergroup/templates/core/operatorgroup.yaml
 ---


### PR DESCRIPTION
bug: Invalid OperatorGroup generated when ommitting targetNamespaces

Problem Statement:
When setting a namespace like this:
    - openshift-distributed-tracing:
        operatorGroup: true
        targetNamespaces: []

The chart generates the following yaml:
```yaml
apiVersion: operators.coreos.com/v1
kind: OperatorGroup
metadata:
  name: openshift-distributed-tracing-operator-group
  namespace: openshift-distributed-tracing
spec:
  targetNamespaces:
```

Which k8s rejects the targetNamespaces key as invalid when it attempts to apply it and removes it since it doesn't have a value, which just so happens to have the desired result of not setting the targetNamespaces (or a selector) to enable it for All Namespaces.
