### PR TITLE
Skip unreachable spokes when setting up vault

### DIFF
--- a/ansible/roles/vault_utils/tasks/vault_spokes_init.yaml
+++ b/ansible/roles/vault_utils/tasks/vault_spokes_init.yaml
@@ -72,6 +72,11 @@
     api_version: v1
     validate_certs: "{{ validate_certs_api_endpoint }}"
   register: remote_external_secrets_sa
+  # We are allowed to ignore errors here because a spoke might be down or unreachable
+  # if a spoke is not reachable then its ['token'] field will not be set which
+  # will leave the ['esoToken'] field empty in the dict which will make it so that
+  # the spoke gets skipped
+  ignore_errors: true
   when:
     - clusters_info[item.key]['bearerToken'] is defined
     - clusters_info[item.key]['server_api'] is defined


### PR DESCRIPTION
When setting up vault we loop through all the managed clusters and set
up the token so ESO can fetch certain paths in vault. This happens in
the unseal vault ansible job and will fail if one of the managed
clusters is unreachable. This is undesirable because a cluster might
have been shut down on purpose or might be temporarily not reachable
and this is no reason to stop the configuration of vault.

Tested as follows:
1. Deployed mcg on sno1 and sno2. All green.
2. Shut off sno2 so it is unreachable. observed unseal-cronjob fail (took a while but eventually failed with:
   ```
   TASK [vault_utils : Fetch remote ansible to remote cluster] ********************
   ok: [localhost] => (item=local-cluster)
   An exception occurred during task execution. To see the full traceback, use -vvv. The error was: urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='api.sno2.ocplab.ocp', port=6443): Max retries exceeded with url: /version (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x7f1e08dd4670>: Failed to establish a new connection: [Errno 110] Connection timed out'))
   failed: [localhost] (item=sno2) => {"ansible_loop_var": "item", "changed": false, "item": {"key": "sno2", "value": {"bearerToken": "eyJhbGciOiJSUzI1...
     ```
3. Imported sno3 into the hub on sno1. observed unseal-cronjob still fail:
   ```
   TASK [vault_utils : Fetch remote ansible to remote cluster] ********************
   ok: [localhost] => (item=local-cluster)
   An exception occurred during task execution. To see the full traceback, use -vvv. The error was: urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='api.sno2.ocplab.ocp', port=6443): Max retries exceeded with url: /version (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x7fb5d293e0a0>: Failed to establish a new connection: [Errno 110] Connection timed out'))
   failed: [localhost] (item=sno2) => {"ansible_loop_var": "item", "changed": false, "item": {"key": "sno2", "value": {"bearerToken": "ey...
   ok: [localhost] => (item=sno3)
   PLAY RECAP *********************************************************************
   localhost : ok=37 changed=11 unreachable=0 failed=1 skipped=13 rescued=0 ignored=0
   ```
4. After the ignore_errors patch:
   ```
   TASK [vault_utils : Fetch remote ansible to remote cluster] ********************
   ok: [localhost] => (item=local-cluster)
   An exception occurred during task execution. To see the full traceback, use -vvv. The error was: urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='api.sno2.ocplab.ocp', port=6443): Max retries exceeded with url: /version (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x7fc4b7805670>: Failed to establish a new connection: [Errno 110] Connection timed out'))
   failed: [localhost] (item=sno2) => {"ansible_loop_var": "item", "changed": false, "item": {"key": "sno2", "value": {"bearerToken": "eyJhb....
   ok: [localhost] => (item=sno3)
   ...ignoring
   # sno2 correctly gets skipped in the subsequent tasks
   ```
   sno3 did manage to login to the vault and everything just worked

Reported-by: François Charette <fcharett@redhat.com>
