### PR TITLE
Update helm version in CI to 3.14.0

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup helm
         uses: azure/setup-helm@v4
         with:
-          version: 'v3.13.2'
+          version: 'v3.14.0'
 
 
       ################################


### PR DESCRIPTION
It's the version gitops 1.12 is using these days:

❯ oc exec -it -n openshift-gitops openshift-gitops-repo-server-66bf746964-926qk -c argocd-repo-server -- bash -c "helm version"
version.BuildInfo{Version:"v3.14.0", GitCommit:"2a2fb3b98829f1e0be6fb18af2f6599e0f4e8243", GitTreeState:"", GoVersion:"go1.21.9 (Red Hat 1.21.9-1.module+el8.10.0+21671+b35c3b78)"}
