### PR TITLE
Fix initcontainer race on spokes

### DIFF
--- a/acm/templates/policies/ocp-gitops-policy.yaml
+++ b/acm/templates/policies/ocp-gitops-policy.yaml
@@ -26,15 +26,6 @@ spec:
           object-templates:
             - complianceType: mustonlyhave
               objectDefinition:
-                kind: ConfigMap
-                apiVersion: v1
-                metadata:
-                  name: trusted-ca-bundle
-                  namespace: openshift-gitops
-                  labels:
-                    config.openshift.io/inject-trusted-cabundle: 'true'
-            - complianceType: mustonlyhave
-              objectDefinition:
                 # This is an auto-generated file. DO NOT EDIT
                 apiVersion: operators.coreos.com/v1alpha1
                 kind: Subscription
@@ -53,6 +44,88 @@ spec:
                     env:
                       - name: ARGOCD_CLUSTER_CONFIG_NAMESPACES
                         value: "*"
+            - complianceType: mustonlyhave
+              objectDefinition:
+                kind: ConfigMap
+                apiVersion: v1
+                metadata:
+                  name: trusted-ca-bundle
+                  namespace: openshift-gitops
+                  labels:
+                    config.openshift.io/inject-trusted-cabundle: 'true'
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: openshift-gitops-placement-binding
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+placementRef:
+  name: openshift-gitops-placement
+  kind: PlacementRule
+  apiGroup: apps.open-cluster-management.io
+subjects:
+  - name: openshift-gitops-policy
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: openshift-gitops-placement
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  clusterConditions:
+    - status: 'True'
+      type: ManagedClusterConditionAvailable
+  clusterSelector:
+    matchExpressions:
+      - key: vendor
+        operator: In
+        values:
+          - OpenShift
+      - key: local-cluster
+        operator: NotIn
+        values:
+          - 'true'
+---
+# This policy depends on openshift-gitops-policy and the reason is that we need to be
+# certain that the trusted-ca-bundle exists before spawning the clusterwide argocd instance
+# because the initcontainer references the trusted-ca-bundle and if it starts without the
+# configmap being there we risk running an argo instances that won't trust public CAs
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: openshift-gitops-policy-argocd
+  annotations:
+    policy.open-cluster-management.io/standards: NIST-CSF
+    policy.open-cluster-management.io/categories: PR.DS Data Security
+    policy.open-cluster-management.io/controls: PR.DS-1 Data-at-rest
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
+spec:
+  remediationAction: enforce
+  disabled: false
+  dependencies:
+    - apiVersion: policy.open-cluster-management.io/v1
+      compliance: Compliant
+      kind: Policy
+      name: openshift-gitops-policy
+      namespace: open-cluster-management
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: openshift-gitops-config-argocd
+        spec:
+          remediationAction: enforce
+          severity: medium
+          namespaceSelector:
+            include:
+              - default
+          object-templates:
             - complianceType: mustonlyhave
               objectDefinition:
                 apiVersion: argoproj.io/v1beta1
@@ -217,22 +290,22 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-  name: openshift-gitops-placement-binding
+  name: openshift-gitops-placement-binding-argocd
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 placementRef:
-  name: openshift-gitops-placement
+  name: openshift-gitops-placement-argocd
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-  - name: openshift-gitops-policy
+  - name: openshift-gitops-policy-argocd
     kind: Policy
     apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
-  name: openshift-gitops-placement
+  name: openshift-gitops-placement-argocd
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:

--- a/tests/acm-industrial-edge-factory.expected.yaml
+++ b/tests/acm-industrial-edge-factory.expected.yaml
@@ -42,10 +42,48 @@ subjects:
     apiGroup: policy.open-cluster-management.io
 ---
 # Source: acm/templates/policies/ocp-gitops-policy.yaml
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: openshift-gitops-placement-binding-argocd
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+placementRef:
+  name: openshift-gitops-placement-argocd
+  kind: PlacementRule
+  apiGroup: apps.open-cluster-management.io
+subjects:
+  - name: openshift-gitops-policy-argocd
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
+---
+# Source: acm/templates/policies/ocp-gitops-policy.yaml
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: openshift-gitops-placement
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  clusterConditions:
+    - status: 'True'
+      type: ManagedClusterConditionAvailable
+  clusterSelector:
+    matchExpressions:
+      - key: vendor
+        operator: In
+        values:
+          - OpenShift
+      - key: local-cluster
+        operator: NotIn
+        values:
+          - 'true'
+---
+# Source: acm/templates/policies/ocp-gitops-policy.yaml
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: openshift-gitops-placement-argocd
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
@@ -92,15 +130,6 @@ spec:
           object-templates:
             - complianceType: mustonlyhave
               objectDefinition:
-                kind: ConfigMap
-                apiVersion: v1
-                metadata:
-                  name: trusted-ca-bundle
-                  namespace: openshift-gitops
-                  labels:
-                    config.openshift.io/inject-trusted-cabundle: 'true'
-            - complianceType: mustonlyhave
-              objectDefinition:
                 # This is an auto-generated file. DO NOT EDIT
                 apiVersion: operators.coreos.com/v1alpha1
                 kind: Subscription
@@ -119,6 +148,53 @@ spec:
                     env:
                       - name: ARGOCD_CLUSTER_CONFIG_NAMESPACES
                         value: "*"
+            - complianceType: mustonlyhave
+              objectDefinition:
+                kind: ConfigMap
+                apiVersion: v1
+                metadata:
+                  name: trusted-ca-bundle
+                  namespace: openshift-gitops
+                  labels:
+                    config.openshift.io/inject-trusted-cabundle: 'true'
+---
+# Source: acm/templates/policies/ocp-gitops-policy.yaml
+# This policy depends on openshift-gitops-policy and the reason is that we need to be
+# certain that the trusted-ca-bundle exists before spawning the clusterwide argocd instance
+# because the initcontainer references the trusted-ca-bundle and if it starts without the
+# configmap being there we risk running an argo instances that won't trust public CAs
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: openshift-gitops-policy-argocd
+  annotations:
+    policy.open-cluster-management.io/standards: NIST-CSF
+    policy.open-cluster-management.io/categories: PR.DS Data Security
+    policy.open-cluster-management.io/controls: PR.DS-1 Data-at-rest
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
+spec:
+  remediationAction: enforce
+  disabled: false
+  dependencies:
+    - apiVersion: policy.open-cluster-management.io/v1
+      compliance: Compliant
+      kind: Policy
+      name: openshift-gitops-policy
+      namespace: open-cluster-management
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: openshift-gitops-config-argocd
+        spec:
+          remediationAction: enforce
+          severity: medium
+          namespaceSelector:
+            include:
+              - default
+          object-templates:
             - complianceType: mustonlyhave
               objectDefinition:
                 apiVersion: argoproj.io/v1beta1

--- a/tests/acm-industrial-edge-hub.expected.yaml
+++ b/tests/acm-industrial-edge-hub.expected.yaml
@@ -70,6 +70,22 @@ subjects:
     kind: Policy
     apiGroup: policy.open-cluster-management.io
 ---
+# Source: acm/templates/policies/ocp-gitops-policy.yaml
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: openshift-gitops-placement-binding-argocd
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+placementRef:
+  name: openshift-gitops-placement-argocd
+  kind: PlacementRule
+  apiGroup: apps.open-cluster-management.io
+subjects:
+  - name: openshift-gitops-policy-argocd
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
+---
 # Source: acm/templates/policies/acm-hub-ca-policy.yaml
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
@@ -119,6 +135,28 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: openshift-gitops-placement
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  clusterConditions:
+    - status: 'True'
+      type: ManagedClusterConditionAvailable
+  clusterSelector:
+    matchExpressions:
+      - key: vendor
+        operator: In
+        values:
+          - OpenShift
+      - key: local-cluster
+        operator: NotIn
+        values:
+          - 'true'
+---
+# Source: acm/templates/policies/ocp-gitops-policy.yaml
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: openshift-gitops-placement-argocd
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
@@ -300,15 +338,6 @@ spec:
           object-templates:
             - complianceType: mustonlyhave
               objectDefinition:
-                kind: ConfigMap
-                apiVersion: v1
-                metadata:
-                  name: trusted-ca-bundle
-                  namespace: openshift-gitops
-                  labels:
-                    config.openshift.io/inject-trusted-cabundle: 'true'
-            - complianceType: mustonlyhave
-              objectDefinition:
                 # This is an auto-generated file. DO NOT EDIT
                 apiVersion: operators.coreos.com/v1alpha1
                 kind: Subscription
@@ -327,6 +356,53 @@ spec:
                     env:
                       - name: ARGOCD_CLUSTER_CONFIG_NAMESPACES
                         value: "*"
+            - complianceType: mustonlyhave
+              objectDefinition:
+                kind: ConfigMap
+                apiVersion: v1
+                metadata:
+                  name: trusted-ca-bundle
+                  namespace: openshift-gitops
+                  labels:
+                    config.openshift.io/inject-trusted-cabundle: 'true'
+---
+# Source: acm/templates/policies/ocp-gitops-policy.yaml
+# This policy depends on openshift-gitops-policy and the reason is that we need to be
+# certain that the trusted-ca-bundle exists before spawning the clusterwide argocd instance
+# because the initcontainer references the trusted-ca-bundle and if it starts without the
+# configmap being there we risk running an argo instances that won't trust public CAs
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: openshift-gitops-policy-argocd
+  annotations:
+    policy.open-cluster-management.io/standards: NIST-CSF
+    policy.open-cluster-management.io/categories: PR.DS Data Security
+    policy.open-cluster-management.io/controls: PR.DS-1 Data-at-rest
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
+spec:
+  remediationAction: enforce
+  disabled: false
+  dependencies:
+    - apiVersion: policy.open-cluster-management.io/v1
+      compliance: Compliant
+      kind: Policy
+      name: openshift-gitops-policy
+      namespace: open-cluster-management
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: openshift-gitops-config-argocd
+        spec:
+          remediationAction: enforce
+          severity: medium
+          namespaceSelector:
+            include:
+              - default
+          object-templates:
             - complianceType: mustonlyhave
               objectDefinition:
                 apiVersion: argoproj.io/v1beta1

--- a/tests/acm-medical-diagnosis-hub.expected.yaml
+++ b/tests/acm-medical-diagnosis-hub.expected.yaml
@@ -70,6 +70,22 @@ subjects:
     kind: Policy
     apiGroup: policy.open-cluster-management.io
 ---
+# Source: acm/templates/policies/ocp-gitops-policy.yaml
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: openshift-gitops-placement-binding-argocd
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+placementRef:
+  name: openshift-gitops-placement-argocd
+  kind: PlacementRule
+  apiGroup: apps.open-cluster-management.io
+subjects:
+  - name: openshift-gitops-policy-argocd
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
+---
 # Source: acm/templates/policies/acm-hub-ca-policy.yaml
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
@@ -110,6 +126,28 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: openshift-gitops-placement
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  clusterConditions:
+    - status: 'True'
+      type: ManagedClusterConditionAvailable
+  clusterSelector:
+    matchExpressions:
+      - key: vendor
+        operator: In
+        values:
+          - OpenShift
+      - key: local-cluster
+        operator: NotIn
+        values:
+          - 'true'
+---
+# Source: acm/templates/policies/ocp-gitops-policy.yaml
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: openshift-gitops-placement-argocd
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
@@ -291,15 +329,6 @@ spec:
           object-templates:
             - complianceType: mustonlyhave
               objectDefinition:
-                kind: ConfigMap
-                apiVersion: v1
-                metadata:
-                  name: trusted-ca-bundle
-                  namespace: openshift-gitops
-                  labels:
-                    config.openshift.io/inject-trusted-cabundle: 'true'
-            - complianceType: mustonlyhave
-              objectDefinition:
                 # This is an auto-generated file. DO NOT EDIT
                 apiVersion: operators.coreos.com/v1alpha1
                 kind: Subscription
@@ -318,6 +347,53 @@ spec:
                     env:
                       - name: ARGOCD_CLUSTER_CONFIG_NAMESPACES
                         value: "*"
+            - complianceType: mustonlyhave
+              objectDefinition:
+                kind: ConfigMap
+                apiVersion: v1
+                metadata:
+                  name: trusted-ca-bundle
+                  namespace: openshift-gitops
+                  labels:
+                    config.openshift.io/inject-trusted-cabundle: 'true'
+---
+# Source: acm/templates/policies/ocp-gitops-policy.yaml
+# This policy depends on openshift-gitops-policy and the reason is that we need to be
+# certain that the trusted-ca-bundle exists before spawning the clusterwide argocd instance
+# because the initcontainer references the trusted-ca-bundle and if it starts without the
+# configmap being there we risk running an argo instances that won't trust public CAs
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: openshift-gitops-policy-argocd
+  annotations:
+    policy.open-cluster-management.io/standards: NIST-CSF
+    policy.open-cluster-management.io/categories: PR.DS Data Security
+    policy.open-cluster-management.io/controls: PR.DS-1 Data-at-rest
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
+spec:
+  remediationAction: enforce
+  disabled: false
+  dependencies:
+    - apiVersion: policy.open-cluster-management.io/v1
+      compliance: Compliant
+      kind: Policy
+      name: openshift-gitops-policy
+      namespace: open-cluster-management
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: openshift-gitops-config-argocd
+        spec:
+          remediationAction: enforce
+          severity: medium
+          namespaceSelector:
+            include:
+              - default
+          object-templates:
             - complianceType: mustonlyhave
               objectDefinition:
                 apiVersion: argoproj.io/v1beta1

--- a/tests/acm-naked.expected.yaml
+++ b/tests/acm-naked.expected.yaml
@@ -42,10 +42,48 @@ subjects:
     apiGroup: policy.open-cluster-management.io
 ---
 # Source: acm/templates/policies/ocp-gitops-policy.yaml
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: openshift-gitops-placement-binding-argocd
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+placementRef:
+  name: openshift-gitops-placement-argocd
+  kind: PlacementRule
+  apiGroup: apps.open-cluster-management.io
+subjects:
+  - name: openshift-gitops-policy-argocd
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
+---
+# Source: acm/templates/policies/ocp-gitops-policy.yaml
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: openshift-gitops-placement
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  clusterConditions:
+    - status: 'True'
+      type: ManagedClusterConditionAvailable
+  clusterSelector:
+    matchExpressions:
+      - key: vendor
+        operator: In
+        values:
+          - OpenShift
+      - key: local-cluster
+        operator: NotIn
+        values:
+          - 'true'
+---
+# Source: acm/templates/policies/ocp-gitops-policy.yaml
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: openshift-gitops-placement-argocd
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
@@ -92,15 +130,6 @@ spec:
           object-templates:
             - complianceType: mustonlyhave
               objectDefinition:
-                kind: ConfigMap
-                apiVersion: v1
-                metadata:
-                  name: trusted-ca-bundle
-                  namespace: openshift-gitops
-                  labels:
-                    config.openshift.io/inject-trusted-cabundle: 'true'
-            - complianceType: mustonlyhave
-              objectDefinition:
                 # This is an auto-generated file. DO NOT EDIT
                 apiVersion: operators.coreos.com/v1alpha1
                 kind: Subscription
@@ -119,6 +148,53 @@ spec:
                     env:
                       - name: ARGOCD_CLUSTER_CONFIG_NAMESPACES
                         value: "*"
+            - complianceType: mustonlyhave
+              objectDefinition:
+                kind: ConfigMap
+                apiVersion: v1
+                metadata:
+                  name: trusted-ca-bundle
+                  namespace: openshift-gitops
+                  labels:
+                    config.openshift.io/inject-trusted-cabundle: 'true'
+---
+# Source: acm/templates/policies/ocp-gitops-policy.yaml
+# This policy depends on openshift-gitops-policy and the reason is that we need to be
+# certain that the trusted-ca-bundle exists before spawning the clusterwide argocd instance
+# because the initcontainer references the trusted-ca-bundle and if it starts without the
+# configmap being there we risk running an argo instances that won't trust public CAs
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: openshift-gitops-policy-argocd
+  annotations:
+    policy.open-cluster-management.io/standards: NIST-CSF
+    policy.open-cluster-management.io/categories: PR.DS Data Security
+    policy.open-cluster-management.io/controls: PR.DS-1 Data-at-rest
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
+spec:
+  remediationAction: enforce
+  disabled: false
+  dependencies:
+    - apiVersion: policy.open-cluster-management.io/v1
+      compliance: Compliant
+      kind: Policy
+      name: openshift-gitops-policy
+      namespace: open-cluster-management
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: openshift-gitops-config-argocd
+        spec:
+          remediationAction: enforce
+          severity: medium
+          namespaceSelector:
+            include:
+              - default
+          object-templates:
             - complianceType: mustonlyhave
               objectDefinition:
                 apiVersion: argoproj.io/v1beta1

--- a/tests/acm-normal.expected.yaml
+++ b/tests/acm-normal.expected.yaml
@@ -860,6 +860,22 @@ subjects:
     kind: Policy
     apiGroup: policy.open-cluster-management.io
 ---
+# Source: acm/templates/policies/ocp-gitops-policy.yaml
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: openshift-gitops-placement-binding-argocd
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+placementRef:
+  name: openshift-gitops-placement-argocd
+  kind: PlacementRule
+  apiGroup: apps.open-cluster-management.io
+subjects:
+  - name: openshift-gitops-policy-argocd
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
+---
 # Source: acm/templates/policies/acm-hub-ca-policy.yaml
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
@@ -928,6 +944,28 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: openshift-gitops-placement
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  clusterConditions:
+    - status: 'True'
+      type: ManagedClusterConditionAvailable
+  clusterSelector:
+    matchExpressions:
+      - key: vendor
+        operator: In
+        values:
+          - OpenShift
+      - key: local-cluster
+        operator: NotIn
+        values:
+          - 'true'
+---
+# Source: acm/templates/policies/ocp-gitops-policy.yaml
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: openshift-gitops-placement-argocd
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
@@ -1303,15 +1341,6 @@ spec:
           object-templates:
             - complianceType: mustonlyhave
               objectDefinition:
-                kind: ConfigMap
-                apiVersion: v1
-                metadata:
-                  name: trusted-ca-bundle
-                  namespace: openshift-gitops
-                  labels:
-                    config.openshift.io/inject-trusted-cabundle: 'true'
-            - complianceType: mustonlyhave
-              objectDefinition:
                 # This is an auto-generated file. DO NOT EDIT
                 apiVersion: operators.coreos.com/v1alpha1
                 kind: Subscription
@@ -1330,6 +1359,53 @@ spec:
                     env:
                       - name: ARGOCD_CLUSTER_CONFIG_NAMESPACES
                         value: "*"
+            - complianceType: mustonlyhave
+              objectDefinition:
+                kind: ConfigMap
+                apiVersion: v1
+                metadata:
+                  name: trusted-ca-bundle
+                  namespace: openshift-gitops
+                  labels:
+                    config.openshift.io/inject-trusted-cabundle: 'true'
+---
+# Source: acm/templates/policies/ocp-gitops-policy.yaml
+# This policy depends on openshift-gitops-policy and the reason is that we need to be
+# certain that the trusted-ca-bundle exists before spawning the clusterwide argocd instance
+# because the initcontainer references the trusted-ca-bundle and if it starts without the
+# configmap being there we risk running an argo instances that won't trust public CAs
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: openshift-gitops-policy-argocd
+  annotations:
+    policy.open-cluster-management.io/standards: NIST-CSF
+    policy.open-cluster-management.io/categories: PR.DS Data Security
+    policy.open-cluster-management.io/controls: PR.DS-1 Data-at-rest
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
+spec:
+  remediationAction: enforce
+  disabled: false
+  dependencies:
+    - apiVersion: policy.open-cluster-management.io/v1
+      compliance: Compliant
+      kind: Policy
+      name: openshift-gitops-policy
+      namespace: open-cluster-management
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: openshift-gitops-config-argocd
+        spec:
+          remediationAction: enforce
+          severity: medium
+          namespaceSelector:
+            include:
+              - default
+          object-templates:
             - complianceType: mustonlyhave
               objectDefinition:
                 apiVersion: argoproj.io/v1beta1


### PR DESCRIPTION
initContainers on the clusterwide argo instances on spokes rely on a
configmap called "trusted-ca-bundle" that gets created by ACM in the
openshift-gitops namespace.

Since we have no explicit guarantees about ordering, it might happen
that the argocd object gets created by acm before the configmap. This
is problematic because the init container will start but just ignore
the missing configmap.

Solve this by splitting the ocp-gitops-policy in two and making sure
that both the openshift-gitops subscription and the trusted-ca-bundle
configmap are green before applying the next dependency.
