### PR TITLE
Drop imperative.volumes and imperative.volumemounts

### DIFF
--- a/clustergroup/templates/imperative/_helpers.tpl
+++ b/clustergroup/templates/imperative/_helpers.tpl
@@ -98,22 +98,6 @@
 - mountPath: /tmp/ca-bundles
   name: ca-bundles
 {{- end }}
-{{- define "imperative.volumemounts" }}
-- name: git
-  mountPath: "/git"
-- name: values-volume
-  mountPath: /values/values.yaml
-  subPath: values.yaml
-{{- end }}
-
-{{/* volumes for all containers */}}
-{{- define "imperative.volumes" }}
-- name: git
-  emptyDir: {}
-- name: values-volume
-  configMap:
-    name: {{ $.Values.clusterGroup.imperative.valuesConfigMap }}-{{ $.Values.clusterGroup.name }}
-{{- end }}
 
 {{- define "imperative.volumes_ca" }}
 - name: git


### PR DESCRIPTION
With the switch to initcontainers they are not used anywhere anymore
