### PR TITLE
Properly quote vault kv command

### DIFF
--- a/ansible/plugins/modules/vault_load_parsed_secrets.py
+++ b/ansible/plugins/modules/vault_load_parsed_secrets.py
@@ -215,7 +215,7 @@ class VaultSecretLoader:
         for prefix in prefixes:
             cmd = (
                 f"oc exec -n {self.namespace} {self.pod} -i -- sh -c "
-                f"\"vault kv {verb} -mount={mount} {prefix}/{secret_name} {fieldname}='{fieldvalue}'\""
+                f"\"vault kv {verb} -mount={mount} {prefix}/{secret_name} {fieldname}='\"'{fieldvalue}'\"'\""
             )
             self._run_command(cmd, attempts=3)
         return

--- a/ansible/tests/unit/test_vault_load_parsed_secrets.py
+++ b/ansible/tests/unit/test_vault_load_parsed_secrets.py
@@ -120,7 +120,7 @@ class TestMyModule(unittest.TestCase):
                 attempts=3,
             ),
             call(
-                "oc exec -n vault vault-0 -i -- sh -c \"vault kv put -mount=secret hub/config-demo secret='value123'\"",
+                "oc exec -n vault vault-0 -i -- sh -c \"vault kv put -mount=secret hub/config-demo secret='\"'value123'\"'\"",  # noqa: E501
                 attempts=3,
             ),
         ]
@@ -159,7 +159,7 @@ class TestMyModule(unittest.TestCase):
                 attempts=3,
             ),
             call(
-                "oc exec -n vault vault-0 -i -- sh -c \"vault kv put -mount=secret hub/config-demo secret='dmFsdWUxMjMK'\"",  # noqa: E501
+                "oc exec -n vault vault-0 -i -- sh -c \"vault kv put -mount=secret hub/config-demo secret='\"'dmFsdWUxMjMK'\"'\"",  # noqa: E501
                 attempts=3,
             ),
         ]
@@ -198,11 +198,11 @@ class TestMyModule(unittest.TestCase):
                 attempts=3,
             ),
             call(
-                "oc exec -n vault vault-0 -i -- sh -c \"vault kv put -mount=secret secret/region-one/config-demo secret='value123'\"",  # noqa: E501
+                "oc exec -n vault vault-0 -i -- sh -c \"vault kv put -mount=secret secret/region-one/config-demo secret='\"'value123'\"'\"",  # noqa: E501
                 attempts=3,
             ),
             call(
-                "oc exec -n vault vault-0 -i -- sh -c \"vault kv put -mount=secret secret/snowflake.blueprints.rhecoeng.com/config-demo secret='value123'\"",  # noqa: E501
+                "oc exec -n vault vault-0 -i -- sh -c \"vault kv put -mount=secret secret/snowflake.blueprints.rhecoeng.com/config-demo secret='\"'value123'\"'\"",  # noqa: E501
                 attempts=3,
             ),
             call(
@@ -249,11 +249,11 @@ class TestMyModule(unittest.TestCase):
                 attempts=3,
             ),
             call(
-                "oc exec -n vault vault-0 -i -- sh -c \"vault kv put -mount=secret secret/region-one/config-demo secret='value123'\"",  # noqa: E501
+                "oc exec -n vault vault-0 -i -- sh -c \"vault kv put -mount=secret secret/region-one/config-demo secret='\"'value123'\"'\"",  # noqa: E501
                 attempts=3,
             ),
             call(
-                "oc exec -n vault vault-0 -i -- sh -c \"vault kv put -mount=secret secret/snowflake.blueprints.rhecoeng.com/config-demo secret='value123'\"",  # noqa: E501
+                "oc exec -n vault vault-0 -i -- sh -c \"vault kv put -mount=secret secret/snowflake.blueprints.rhecoeng.com/config-demo secret='\"'value123'\"'\"",  # noqa: E501
                 attempts=3,
             ),
             call(


### PR DESCRIPTION
When using a password with a dollar, the oc exec commands run inside the
vault are not properly escaped, casing the dollar signed to be
interpreted by the shell inside the vault pod.

So a password like 'Y$yxn54&qXAxpUd2*yGH' will become 'Y&qXAxpUd2*yGH'
in the vault.

This is because the command that is being run ends up being:

    oc exec -n vault vault-0 -i -- sh -c "vault kv patch -mount=secret global/mysecret dollar=Y$yxn54&qXAxpUd2*yGH"

The `$yxn54` will be interpreted by the shell inside vault.

Let's fix this by running a properly escaped command:

    oc exec -n vault vault-0 -i -- sh -c "vault kv patch -mount=secret global/mysecret dollar='"'Y$yxn54&qXAxpUd2*yGH'"'"

Reported-By: Chris Butler <chris.butler@redhat.com>
