### PR TITLE
Allow originRepo to be set via make install and main.git parameters

### DIFF
--- a/clustergroup/values.schema.json
+++ b/clustergroup/values.schema.json
@@ -81,6 +81,10 @@
             "revision"
           ],
           "properties": {
+            "repoUpstreamURL": {
+              "type": "string",
+              "description": "Upstream URL of the pattern's git repository. When set an in-cluster gitea instance gets spawned and repoURL is ignored"
+            },
             "repoURL": {
               "type": "string",
               "description": "URL of the pattern's git repository"

--- a/operator-install/templates/pattern.yaml
+++ b/operator-install/templates/pattern.yaml
@@ -6,6 +6,9 @@ metadata:
 spec:
   clusterGroupName: {{ .Values.main.clusterGroupName }}
   gitSpec:
+{{- if .Values.main.git.repoUpstreamURL }}
+    originRepo: {{ .Values.main.git.repoUpstreamURL }}
+{{- end }} {{/* if .Values.main.git.repoUpstreamURL */}}
     targetRepo: {{ .Values.main.git.repoURL }}
     targetRevision: {{ .Values.main.git.revision }}
 {{- if and .Values.main.tokenSecret .Values.main.tokenSecretNamespace }}

--- a/operator-install/values.yaml
+++ b/operator-install/values.yaml
@@ -3,6 +3,11 @@ global:
 
 main:
   git:
+    # Uncommenting this will set the `originRepo` with the below value
+    # when `originRepo` is set, an in-cluster gitea will automatically be spawned.
+    # In this case `originRepo` will point to the upstream repository and `targetRepo`
+    # will point to the internal in-cluster gitea mirror
+    # repoUpstreamURL: https://github.com/validatedpatterns/multicloud-gitops
     repoURL: https://github.com/pattern-clone/mypattern
     revision: main
 

--- a/tests/operator-install-industrial-edge-factory.expected.yaml
+++ b/tests/operator-install-industrial-edge-factory.expected.yaml
@@ -22,7 +22,7 @@ metadata:
   namespace: openshift-operators
 spec:
   clusterGroupName: example
-  gitSpec:
+  gitSpec: 
     targetRepo: https://github.com/pattern-clone/mypattern
     targetRevision: main 
   multiSourceConfig:

--- a/tests/operator-install-industrial-edge-hub.expected.yaml
+++ b/tests/operator-install-industrial-edge-hub.expected.yaml
@@ -22,7 +22,7 @@ metadata:
   namespace: openshift-operators
 spec:
   clusterGroupName: example
-  gitSpec:
+  gitSpec: 
     targetRepo: https://github.com/pattern-clone/mypattern
     targetRevision: main 
   multiSourceConfig:

--- a/tests/operator-install-medical-diagnosis-hub.expected.yaml
+++ b/tests/operator-install-medical-diagnosis-hub.expected.yaml
@@ -22,7 +22,7 @@ metadata:
   namespace: openshift-operators
 spec:
   clusterGroupName: example
-  gitSpec:
+  gitSpec: 
     targetRepo: https://github.com/pattern-clone/mypattern
     targetRevision: main 
   multiSourceConfig:

--- a/tests/operator-install-naked.expected.yaml
+++ b/tests/operator-install-naked.expected.yaml
@@ -22,7 +22,7 @@ metadata:
   namespace: openshift-operators
 spec:
   clusterGroupName: default
-  gitSpec:
+  gitSpec: 
     targetRepo: https://github.com/pattern-clone/mypattern
     targetRevision: main 
   multiSourceConfig:

--- a/tests/operator-install-normal.expected.yaml
+++ b/tests/operator-install-normal.expected.yaml
@@ -22,7 +22,7 @@ metadata:
   namespace: openshift-operators
 spec:
   clusterGroupName: example
-  gitSpec:
+  gitSpec: 
     targetRepo: https://github.com/pattern-clone/mypattern
     targetRevision: main 
   multiSourceConfig:


### PR DESCRIPTION
We introduce the `main.git.repoUpstreamURL` parameter. This can be used
to set `originRepo`.

When `originRepo` is set, an in-cluster gitea will automatically be spawned.
In this case `originRepo` will point to the upstream repository and `targetRepo`
will point to the internal in-cluster gitea mirror.
