### PR TITLE
Allow more flexibility with multiSourceConfig schema

### DIFF
--- a/clustergroup/values.schema.json
+++ b/clustergroup/values.schema.json
@@ -107,11 +107,15 @@
         },
         "multiSourceConfig": {
           "type": "object",
-          "additionalProperties": false,
+          "additionalProperties": true,
           "properties": {
             "enabled": {
               "type": "boolean",
-              "description": "Enable the experimental support for multi source"
+              "description": "Enable the experimental support for multi source for the clustergroup chart"
+            },
+            "helmRepoUrl": {
+              "type": "string",
+              "description": "The helm repo URL for the clustergroup chart"
             }
           }
         },


### PR DESCRIPTION
We specifically also add helmRepoUrl as it make it more discoverable,
but we stay flexible in what we accept so that things can be extended
without having to be in lockstep with the operator.
