### PR TITLE
Add a pushsecrets policy and vault path for ESO syncing

### DIFF
--- a/ansible/roles/vault_utils/README.md
+++ b/ansible/roles/vault_utils/README.md
@@ -40,6 +40,17 @@ unseal_namespace: "imperative"
 
 This relies on [kubernetes.core](https://docs.ansible.com/ansible/latest/collections/kubernetes/core/k8s_module.html)
 
+## Vault out of the box configuration
+
+This role configures four secret paths in vault:
+
+1. `secret/global` - Any secret under this path is accessible in read-only only to all clusters known to ACM (hub and spokes)
+2. `secret/hub` - Any secret under this path is accessible in read-only only to the ACM hub cluster
+3. `secret/<fqdn.of.spoke.cluster>` - Any secret under this path is accessible in read-only only to the spoke cluster
+4. `secret/pushsecrets` - Any secret here can be accessed in read and write mode to all clusters known to ACM. This area can
+   be used with ESO's `PushSecrets` so you can push an existing secret from one namespace, to the vault under this path and
+   then it can be retrieved by an `ExternalSecret` either in a different namespace *or* from an entirely different cluster.
+
 ## Values secret file format
 
 Currently this role supports two formats: version 1.0 (which is the assumed
@@ -57,46 +68,6 @@ secret file.
 
 The values secret YAML files can be encrypted with `ansible-vault`. If the role detects they are encrypted, the password to
 decrypt them will be prompted when needed.
-
-### Version 1.0
-
-Here is a well-commented example of a version 1.0 file:
-
-```yaml
----
-# By default when a top-level 'version: 1.0' is missing it is assumed to be '1.0'
-# NEVER COMMIT THESE VALUES TO GIT
-
-secrets:
-  # These secrets will be pushed in the vault at secret/hub/test The vault will
-  # have secret/hub/test with secret1 and secret2 as keys with their associated
-  # values (secrets)
-  test:
-    secret1: foo
-    secret2: bar
-
-  # This ends up as the s3Secret attribute to the path secret/hub/aws
-  aws:
-    s3Secret: test-secret
-
-# This will create the vault key secret/hub/testfoo which will have two
-# properties 'b64content' and 'content' which will be the base64-encoded
-# content and the normal content respectively
-files:
-  testfoo: ~/ca.crt
-# These secrets will be pushed in the vault at secret/region1/test The vault will
-# have secret/region1/test with secret1 and secret2 as keys with their associated
-# values (secrets)
-secrets.region1:
-  test:
-    secret1: foo1
-    secret2: bar1
-# This will create the vault key secret/region2/testbar which will have two
-# properties 'b64content' and 'content' which will be the base64-encoded
-# content and the normal content respectively
-files.region2:
-  testbar: ~/ca.crt
-```
 
 ### Version 2.0
 
@@ -208,6 +179,46 @@ secrets:
     - name: aws_secret_access_key_test
       ini_file: ~/.aws/credentials
       ini_key: aws_secret_access_key
+```
+
+### Version 1.0
+
+Here is a well-commented example of a version 1.0 file:
+
+```yaml
+---
+# By default when a top-level 'version: 1.0' is missing it is assumed to be '1.0'
+# NEVER COMMIT THESE VALUES TO GIT
+
+secrets:
+  # These secrets will be pushed in the vault at secret/hub/test The vault will
+  # have secret/hub/test with secret1 and secret2 as keys with their associated
+  # values (secrets)
+  test:
+    secret1: foo
+    secret2: bar
+
+  # This ends up as the s3Secret attribute to the path secret/hub/aws
+  aws:
+    s3Secret: test-secret
+
+# This will create the vault key secret/hub/testfoo which will have two
+# properties 'b64content' and 'content' which will be the base64-encoded
+# content and the normal content respectively
+files:
+  testfoo: ~/ca.crt
+# These secrets will be pushed in the vault at secret/region1/test The vault will
+# have secret/region1/test with secret1 and secret2 as keys with their associated
+# values (secrets)
+secrets.region1:
+  test:
+    secret1: foo1
+    secret2: bar1
+# This will create the vault key secret/region2/testbar which will have two
+# properties 'b64content' and 'content' which will be the base64-encoded
+# content and the normal content respectively
+files.region2:
+  testbar: ~/ca.crt
 ```
 
 Internals

--- a/ansible/roles/vault_utils/defaults/main.yml
+++ b/ansible/roles/vault_utils/defaults/main.yml
@@ -17,6 +17,8 @@ vault_spoke_capabilities: '[\\\"read\\\"]'
 vault_spoke_ttl: "15m"
 vault_global_policy: global
 vault_global_capabilities: '[\\\"read\\\"]'
+vault_pushsecrets_policy: pushsecrets
+vault_pushsecrets_capabilities: '[\\\"create\\\",\\\"read\\\",\\\"update\\\",\\\"delete\\\"]'
 external_secrets_ns: golang-external-secrets
 external_secrets_sa: golang-external-secrets
 external_secrets_secret: golang-external-secrets

--- a/ansible/roles/vault_utils/tasks/vault_secrets_init.yaml
+++ b/ansible/roles/vault_utils/tasks/vault_secrets_init.yaml
@@ -71,6 +71,28 @@
     pod: "{{ vault_pod }}"
     command: "vault policy write {{ vault_global_policy }}-secret /tmp/policy-{{ vault_global_policy }}.hcl"
 
+- name: Configure VP pushsecrets policy template
+  kubernetes.core.k8s_exec:
+    namespace: "{{ vault_ns }}"
+    pod: "{{ vault_pod }}"
+    command: >
+      bash -e -c "echo \"path \\\"secret/data/{{ vault_pushsecrets_policy }}/*\\\" {
+        capabilities = {{ vault_pushsecrets_capabilities }} }\" > /tmp/policy-{{ vault_pushsecrets_policy }}.hcl"
+
+- name: Add metadata path to the pushsecrets policy
+  kubernetes.core.k8s_exec:
+      namespace: "{{ vault_ns }}"
+      pod: "{{ vault_pod }}"
+      command: >
+        bash -e -c "echo \"path \\\"secret/metadata/{{ vault_pushsecrets_policy }}/*\\\" {
+          capabilities = {{ vault_pushsecrets_capabilities }} }\" >> /tmp/policy-{{ vault_pushsecrets_policy }}.hcl"
+
+- name: Configure VP pushsecrets policy
+  kubernetes.core.k8s_exec:
+    namespace: "{{ vault_ns }}"
+    pod: "{{ vault_pod }}"
+    command: "vault policy write {{ vault_pushsecrets_policy }}-secret /tmp/policy-{{ vault_pushsecrets_policy }}.hcl"
+
 - name: Configure policy template for hub
   kubernetes.core.k8s_exec:
     namespace: "{{ vault_ns }}"
@@ -93,4 +115,4 @@
       vault write auth/"{{ vault_hub }}"/role/"{{ vault_hub }}"-role
         bound_service_account_names="{{ external_secrets_sa }}"
         bound_service_account_namespaces="{{ external_secrets_ns }}"
-        policies="default,{{ vault_global_policy }}-secret,{{ vault_hub }}-secret" ttl="{{ vault_hub_ttl }}"
+        policies="default,{{ vault_global_policy }}-secret,{{ vault_pushsecrets_policy }}-secret,{{ vault_hub }}-secret" ttl="{{ vault_hub_ttl }}"

--- a/ansible/roles/vault_utils/tasks/vault_spokes_init.yaml
+++ b/ansible/roles/vault_utils/tasks/vault_spokes_init.yaml
@@ -157,13 +157,41 @@
   loop_control:
     label: "{{ item.key }}"
 
-- name: Configure policy template
+- name: Configure spoke policy template
   kubernetes.core.k8s_exec:
     namespace: "{{ vault_ns }}"
     pod: "{{ vault_pod }}"
     command: >
       bash -e -c "echo \"path \\\"secret/data/{{ item.value['vault_path'] }}/*\\\" {
         capabilities = {{ vault_spoke_capabilities }} }\" > /tmp/policy-{{ item.value['vault_path'] }}.hcl"
+  loop: "{{ clusters_info | dict2items }}"
+  when:
+    - item.value['esoToken'] is defined
+    - item.key != "local-cluster"
+  loop_control:
+    label: "{{ item.key }}"
+
+- name: Configure spoke pushsecrets policy template
+  kubernetes.core.k8s_exec:
+    namespace: "{{ vault_ns }}"
+    pod: "{{ vault_pod }}"
+    command: >
+      bash -e -c "echo \"path \\\"secret/data/{{ vault_pushsecrets_policy }}/*\\\" {
+        capabilities = {{ vault_pushsecrets_capabilities }} }\" >> /tmp/policy-{{ item.value['vault_path'] }}.hcl"
+  loop: "{{ clusters_info | dict2items }}"
+  when:
+    - item.value['esoToken'] is defined
+    - item.key != "local-cluster"
+  loop_control:
+    label: "{{ item.key }}"
+
+- name: Configure spoke pushsecrets metadata policy template
+  kubernetes.core.k8s_exec:
+    namespace: "{{ vault_ns }}"
+    pod: "{{ vault_pod }}"
+    command: >
+      bash -e -c "echo \"path \\\"secret/metadata/{{ vault_pushsecrets_policy }}/*\\\" {
+        capabilities = {{ vault_pushsecrets_capabilities }} }\" >> /tmp/policy-{{ item.value['vault_path'] }}.hcl"
   loop: "{{ clusters_info | dict2items }}"
   when:
     - item.value['esoToken'] is defined
@@ -191,7 +219,7 @@
       vault write auth/"{{ item.value['vault_path'] }}"/role/"{{ item.value['vault_path'] }}"-role
         bound_service_account_names="{{ external_secrets_sa }}"
         bound_service_account_namespaces="{{ external_secrets_ns }}"
-        policies="default,{{ vault_global_policy }}-secret,{{ item.value['vault_path'] }}-secret" ttl="{{ vault_spoke_ttl }}"
+        policies="default,{{ vault_global_policy }}-secret,{{ vault_pushsecrets_policy }}-secret,{{ item.value['vault_path'] }}-secret" ttl="{{ vault_spoke_ttl }}"
   loop: "{{ clusters_info | dict2items }}"
   when:
     - item.value['esoToken'] is defined


### PR DESCRIPTION
See the README for more details, but TLDR: you can use
`secret/pushsecrets` to push secrets from any node to the vault.
This secret can then be retrieved from either a different namespace
or a different cluster node.

Tested this with a pushsecret as follows:
```
apiVersion: external-secrets.io/v1alpha1
kind: PushSecret
metadata:
  name: pushsecret
  namespace: hello-world
spec:
  data:
    - conversionStrategy: None
      match:
        remoteRef:
          property: baz
          remoteKey: pushsecrets/testme
        secretKey: bar
  deletionPolicy: Delete
  refreshInterval: 10s
  secretStoreRefs:
    - kind: ClusterSecretStore
      name: vault-backend
  selector:
    secret:
      name: existing-secret
  updatePolicy: Replace
```

The above takes the property called `baz` of an existing secret called `existing-secret` in
the `hello-world` namespace and pushes it to the `secret/pushsecrets/testme` vault path.

Suggested-By: Chris Butler <chbutler@redhat.com>

Closes: MBP-641
