### PR TITLE
Also push any changes to operator-install to its own repo

### DIFF
--- a/.github/workflows/chart-branches.yml
+++ b/.github/workflows/chart-branches.yml
@@ -15,6 +15,7 @@ on:
       - 'hashicorp-vault/**'
       - 'letsencrypt/**'
       - 'clustergroup/**'
+      - 'operator-install/**'
 
 jobs:
   changes:
@@ -28,6 +29,7 @@ jobs:
       hashicorp-vault: ${{ steps.filter.outputs.hashicorp-vault }}
       letsencrypt: ${{ steps.filter.outputs.letsencrypt }}
       clustergroup: ${{ steps.filter.outputs.clustergroup }}
+      operator-install: ${{ steps.filter.outputs.operator-install }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -46,6 +48,8 @@ jobs:
               - 'letsencrypt/**'
             clustergroup:
               - 'clustergroup/**'
+            operator-install:
+              - 'operator-install/**'
 
   acm:
     needs: changes
@@ -105,4 +109,17 @@ jobs:
     with:
       chart_name: clustergroup
       target_repository: validatedpatterns/clustergroup-chart
+    secrets: inherit
+
+  # The folder is named 'operator-install' but the chart is called 'pattern-install'
+  operator-install:
+    needs: changes
+    if: ${{ (needs.changes.outputs.operator-install == 'true') && (github.repository == 'validatedpatterns/common') }}
+    uses: validatedpatterns/common/.github/workflows/chart-split.yml@main
+    permissions:
+      actions: write
+      contents: write
+    with:
+      chart_name: pattern-install
+      target_repository: validatedpatterns/pattern-install-chart
     secrets: inherit

--- a/operator-install/.github/workflows/update-helm-repo.yml
+++ b/operator-install/.github/workflows/update-helm-repo.yml
@@ -1,0 +1,30 @@
+# This invokes the workflow named 'publish-charts' in the umbrella repo
+# It expects to have a secret called CHARTS_REPOS_TOKEN which contains
+# the GitHub token that has permissions to invoke workflows and commit code
+# inside the umbrella-repo.
+# The following fine-grained permissions were used in testing and were limited
+# to the umbrella repo only:
+# - Actions: r/w
+# - Commit statuses: r/w
+# - Contents: r/w
+# - Deployments: r/w
+# - Pages: r/w
+#
+
+name: vp-patterns/update-helm-repo
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  helmlint:
+    uses: validatedpatterns/helm-charts/.github/workflows/helmlint.yml@985ba37e0eb50b1b35ec194fc999eae2d0ae1486
+    permissions:
+      contents: read
+
+  update-helm-repo:
+    needs: [helmlint]
+    uses: validatedpatterns/helm-charts/.github/workflows/update-helm-repo.yml@985ba37e0eb50b1b35ec194fc999eae2d0ae1486
+    permissions: read-all
+    secrets: inherit


### PR DESCRIPTION
Since at the time the folder was named operator-install and the chart
pattern-install, let's push it out to the `pattern-install-chart` repo
which is a bit clearer.
