### PR TITLE
Drop schema required under the Main section

### DIFF
--- a/clustergroup/Chart.yaml
+++ b/clustergroup/Chart.yaml
@@ -3,4 +3,4 @@ description: A Helm chart to create per-clustergroup ArgoCD applications and any
 keywords:
 - pattern
 name: clustergroup
-version: 0.8.13
+version: 0.8.14

--- a/clustergroup/values.schema.json
+++ b/clustergroup/values.schema.json
@@ -76,10 +76,6 @@
         "git": {
           "type": "object",
           "additionalProperties": false,
-          "required": [
-            "repoURL",
-            "revision"
-          ],
           "properties": {
             "repoUpstreamURL": {
               "type": "string",


### PR DESCRIPTION
The "main" subsection of helm values is only used for kickstarting a
pattern. It is entirely possible to only set one value and then set the
other variables through other means (editing CRs e.g.). There is no
point on blocking this.
