### PR TITLE
Add a check to see if multisource for clustergroup is enabled

### DIFF
--- a/scripts/pattern-util.sh
+++ b/scripts/pattern-util.sh
@@ -8,6 +8,18 @@ function version {
     echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'
 }
 
+function check_for_clustergroup_multisource {
+    if [ -f values-global.yaml ]; then
+        # Query .main.multiSourceConfig.enabled and assume it is false if not set
+        OUT=$(yq -r '.main.multiSourceConfig.enabled // (.main.multiSourceConfig.enabled = "false")')
+        if [ "${OUT,,}" = "false" ]; then
+            echo "You must set `.main.multiSourceConfig.enabled: true` in your 'values-global.yaml' file"
+            echo "because your common subfolder is the slimmed down version with no helm charts in it"
+            exit 1
+        fi
+    fi
+}
+
 if [ -z "$PATTERN_UTILITY_CONTAINER" ]; then
 	PATTERN_UTILITY_CONTAINER="quay.io/hybridcloudpatterns/utility-container"
 fi
@@ -65,6 +77,10 @@ if [ $REMOTE_PODMAN -eq 0 ]; then # If we are not using podman machine we check 
 else
     PKI_HOST_MOUNT_ARGS=""
 fi
+
+# In the slimmed down common branch we need to check that multisource is enabled for the clustergroup
+# chart
+check_for_clustergroup_multisource
 
 # Copy Kubeconfig from current environment. The utilities will pick up ~/.kube/config if set so it's not mandatory
 # $HOME is mounted as itself for any files that are referenced with absolute paths


### PR DESCRIPTION
Without this in your values-global.yaml files, the deployment with a
slimmed down common would fail as follows:

    - lastTransitionTime: "2024-09-13T18:30:19Z"
    message: 'Failed to load target state: failed to generate manifest for source
      1 of 1: rpc error: code = Unknown desc = Manifest generation error (cached):
      common/clustergroup: app path does not exist'
