### PR TITLE
Move the common slim + multisource test into Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,7 +169,14 @@ validate-prereq: ## verify pre-requisites
 	  if ! ansible-galaxy collection list | grep kubernetes.core > /dev/null 2>&1; then echo "Not found"; exit 1; fi;\
 	  echo "OK";\
 	else\
-	  echo "Skipping prerequisites check as we're running inside a container";\
+		if [ -f values-global.yaml ]; then\
+			OUT=`yq -r '.main.multiSourceConfig.enabled // (.main.multiSourceConfig.enabled = "false")' values-global.yaml`;\
+			if [ "$${OUT,,}" = "false" ]; then\
+				echo "You must set \".main.multiSourceConfig.enabled: true\" in your 'values-global.yaml' file";\
+				echo "because your common subfolder is the slimmed down version with no helm charts in it";\
+				exit 1;\
+			fi;\
+		fi;\
 	fi
 
 .PHONY: argo-healthcheck

--- a/scripts/pattern-util.sh
+++ b/scripts/pattern-util.sh
@@ -8,18 +8,6 @@ function version {
     echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'
 }
 
-function check_for_clustergroup_multisource {
-    if [ -f values-global.yaml ]; then
-        # Query .main.multiSourceConfig.enabled and assume it is false if not set
-        OUT=$(yq -r '.main.multiSourceConfig.enabled // (.main.multiSourceConfig.enabled = "false")')
-        if [ "${OUT,,}" = "false" ]; then
-            echo "You must set `.main.multiSourceConfig.enabled: true` in your 'values-global.yaml' file"
-            echo "because your common subfolder is the slimmed down version with no helm charts in it"
-            exit 1
-        fi
-    fi
-}
-
 if [ -z "$PATTERN_UTILITY_CONTAINER" ]; then
 	PATTERN_UTILITY_CONTAINER="quay.io/hybridcloudpatterns/utility-container"
 fi
@@ -77,10 +65,6 @@ if [ $REMOTE_PODMAN -eq 0 ]; then # If we are not using podman machine we check 
 else
     PKI_HOST_MOUNT_ARGS=""
 fi
-
-# In the slimmed down common branch we need to check that multisource is enabled for the clustergroup
-# chart
-check_for_clustergroup_multisource
 
 # Copy Kubeconfig from current environment. The utilities will pick up ~/.kube/config if set so it's not mandatory
 # $HOME is mounted as itself for any files that are referenced with absolute paths


### PR DESCRIPTION
This way yq is not required on the host. Tested as follows:

* No value set (assumes default is false)

❯ cat values-global.yaml
---
global:
  pattern: multicloud-gitops
  options:
    useCSV: false
    syncPolicy: Automatic
    installPlanApproval: Automatic
main:
  clusterGroupName: hub
  #  multiSourceConfig:
  #  enabled: true

❯ ./pattern.sh make validate-prereq
make -f common/Makefile validate-prereq
make[1]: Entering directory '/home/michele/Engineering/cloud-patterns/multicloud-gitops'
You must set ".main.multiSourceConfig.enabled: true" in your 'values-global.yaml' file
because your common subfolder is the slimmed down version with no helm charts in it
make[1]: *** [common/Makefile:161: validate-prereq] Error 1
make[1]: Leaving directory '/home/michele/Engineering/cloud-patterns/multicloud-gitops'
make: *** [Makefile:12: validate-prereq] Error 2

* Value set to false

❯ cat values-global.yaml
---
global:
  pattern: multicloud-gitops
  options:
    useCSV: false
    syncPolicy: Automatic
    installPlanApproval: Automatic
main:
  clusterGroupName: hub
  multiSourceConfig:
    enabled: false
❯ ./pattern.sh make validate-prereq
make -f common/Makefile validate-prereq
make[1]: Entering directory '/home/michele/Engineering/cloud-patterns/multicloud-gitops'
You must set ".main.multiSourceConfig.enabled: true" in your 'values-global.yaml' file
because your common subfolder is the slimmed down version with no helm charts in it
make[1]: *** [common/Makefile:161: validate-prereq] Error 1
make[1]: Leaving directory '/home/michele/Engineering/cloud-patterns/multicloud-gitops'
make: *** [Makefile:12: validate-prereq] Error 2

* Value set to true

❯ cat values-global.yaml
---
global:
  pattern: multicloud-gitops
  options:
    useCSV: false
    syncPolicy: Automatic
    installPlanApproval: Automatic
main:
  clusterGroupName: hub
  multiSourceConfig:
    enabled: true
❯ ./pattern.sh make validate-prereq
make -f common/Makefile validate-prereq
make[1]: Entering directory '/home/michele/Engineering/cloud-patterns/multicloud-gitops'
make[1]: Leaving directory '/home/michele/Engineering/cloud-patterns/multicloud-gitops'
