### PR TITLE
Make sure we compare lists with lists when doing a difference

### DIFF
--- a/ansible/roles/vault_utils/tasks/vault_status.yaml
+++ b/ansible/roles/vault_utils/tasks/vault_status.yaml
@@ -58,4 +58,4 @@
 
 - name: "Followers"
   ansible.builtin.set_fact:
-    followers: "{{ vault_pods | difference(vault_pod) }}"
+    followers: "{{ vault_pods | difference([vault_pod]) }}"


### PR DESCRIPTION
While this works with older ansible versions (2.15 and before), we
need to check the difference between two lists and not a list and an
item. This breaks with ansible 2.16 and onwards

Tested with newer ansible and the vault now unseals correctly.
