### PR TITLE
Update Makefile to reflect a warning if no storageclass is present

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ validate-cluster: ## Do some cluster validations before installing
 	@oc cluster-info >/dev/null && echo "OK" || (echo "Error"; exit 1)
 	@echo -n "  storageclass: "
 	@if [ `oc get storageclass -o go-template='{{printf "%d\n" (len .items)}}'` -eq 0 ]; then\
-		echo "None Found"; exit 1;\
+		echo "WARNING: No storageclass found";\
 	else\
 		echo "OK";\
 	fi


### PR DESCRIPTION
UPI or bare metal clusters may not have any storage class.

As today, the validate-cluster target in the common/Makefile fails if there's no storage class.

Is there any reason to keep this requirement so strong in the Makefile.

Fixes #607 