### PR TITLE
Fix iib loading playbook name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ secrets-backend-none: ## Edits values files to remove secrets manager + ESO
 .PHONY: load-iib
 load-iib: ## CI target to install Index Image Bundles
 	@set -e; if [ x$(INDEX_IMAGES) != x ]; then \
-		ansible-playbook rhvp.cluster_utils.iib-ci; \
+		ansible-playbook rhvp.cluster_utils.iib_ci; \
 	else \
 		echo "No INDEX_IMAGES defined. Bailing out"; \
 		exit 1; \


### PR DESCRIPTION
After slimming common down the playbook needs renaming because
collections have slightly different naming constraints. Previous error:

❯ ./pattern.sh make load-iib
make -f common/Makefile load-iib
make[1]: Entering directory '/home/michele/Engineering/cloud-patterns/multicloud-gitops'
ERROR! the playbook: rhvp.cluster_utils.iib-ci could not be found
make[1]: *** [common/Makefile:117: load-iib] Error 1
make[1]: Leaving directory '/home/michele/Engineering/cloud-patterns/multicloud-gitops'
make: *** [Makefile:12: load-iib] Error 2
