### PR TITLE
Make the make install output less daunting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,11 +68,7 @@ preview-%:
 
 .PHONY: operator-deploy
 operator-deploy operator-upgrade: validate-prereq validate-origin validate-cluster ## runs helm install
-	@set -e -o pipefail
-	# Retry five times because the CRD might not be fully installed yet
-	for i in {1..5}; do \
-		helm template --include-crds --name-template $(NAME) $(PATTERN_INSTALL_CHART) $(HELM_OPTS) | oc apply -f- && break || sleep 10; \
-	done
+	@common/scripts/deploy-pattern.sh $(NAME) $(PATTERN_INSTALL_CHART) $(HELM_OPTS)
 
 .PHONY: uninstall
 uninstall: ## runs helm uninstall

--- a/scripts/deploy-pattern.sh
+++ b/scripts/deploy-pattern.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -o pipefail
+
+RUNS=5
+# Retry five times because the CRD might not be fully installed yet
+echo -n "Installing pattern: "
+for i in $(seq 1 ${RUNS}); do \
+    exec 3>&1 4>&2
+    OUT=$( { helm template --include-crds --name-template $* 2>&4 | oc apply -f- 2>&4 1>&3; } 4>&1 3>&1)
+    exec 3>&- 4>&-
+    ret=$?
+    if [ ${ret} -eq 0 ]; then
+        break;
+    else
+        echo -n "."
+        sleep 10
+    fi
+done
+
+# All the runs failed
+if [ ${i} -eq ${RUNS} ]; then
+    echo "Installation failed [${i}/${RUNS}]. Error:"
+    echo "${OUT}"
+    exit 1
+fi
+echo "Done"


### PR DESCRIPTION
The current output is a bit daunting for first-time users as it outputs
things like the following a few times:

    customresourcedefinition.apiextensions.k8s.io/patterns.gitops.hybrid-cloud-patterns.io created
    configmap/patterns-operator-config created
    subscription.operators.coreos.com/patterns-operator created
    error: resource mapping not found for name: "rhoai-patterns-demo" namespace: "openshift-operators" from "STDIN": no matches for kind "Pattern" in version "gitops.hybrid-cloud-patterns.io/v1alpha1"
    ensure CRDs are installed first

Let's switch to something a bit more user-friendly:

    make -f common/Makefile operator-deploy
    make[1]: Entering directory '/home/michele/Engineering/cloud-patterns/multicloud-gitops'
    Checking repository:
      https://github.com/mbaldessari/multicloud-gitops.git - branch 'luis-demo': OK
    Checking cluster:
      cluster-info: OK
      storageclass: WARNING: No storageclass found
    Installing pattern: Done
    ...

Do some magic with file descriptors so we still manage to capture the
helm template stderr and the oc apply stdout+stderr and output them at
the end in case of failure.

In such cases the output will be something like the following:

    Installing pattern: .....Installation failed [5/5]. Error:
    Pulled: quay.io/hybridcloudpatterns/pattern-install:0.0.3
    Digest: sha256:dd2d35d462b75aa8358ff278757dca0ee3c878cadafa64df8c68f880b59569ef
    E1015 18:41:31.585465  196315 memcache.go:265] couldn't get current server API group list: Get "https://api.sno3.ocplab.ocp:6443/api?timeout=32s": tls: failed to verify certificate: x509: certificate signed by un
    known authority (possibly because of "crypto/rsa: verification error" while trying to verify candidate authority certificate "kube-apiserver-lb-signer")
    ...

Suggested-by: Luis Tomas Bolivar <ltomasbo@redhat.com>
