### PR TITLE
Record the exit code at the right time

### DIFF
--- a/scripts/deploy-pattern.sh
+++ b/scripts/deploy-pattern.sh
@@ -7,8 +7,8 @@ echo -n "Installing pattern: "
 for i in $(seq 1 ${RUNS}); do \
     exec 3>&1 4>&2
     OUT=$( { helm template --include-crds --name-template $* 2>&4 | oc apply -f- 2>&4 1>&3; } 4>&1 3>&1)
-    exec 3>&- 4>&-
     ret=$?
+    exec 3>&- 4>&-
     if [ ${ret} -eq 0 ]; then
         break;
     else


### PR DESCRIPTION
Otherwise it records the exit code of the exec call which is always 0.

This now makes things error out correctly whereas previously it did not:

    ❯ ./pattern.sh make install
    make -f common/Makefile operator-deploy
    make[1]: Entering directory '/home/michele/Engineering/cloud-patterns/multicloud-gitops'
    Checking repository:
      https://github.com/mbaldessari/multicloud-gitops.git - branch 'debug': OK
    Checking cluster:
      cluster-info: OK
      storageclass: OK
    Installing pattern: .....Installation failed [5/5]. Error:
    Pulled: quay.io/rhn_support_mbaldess/pattern-install:0.0.4
    Digest: sha256:6a5431d257f4bf05d6ac91bca4f4aa010ecb1ee60d2e03c1d0984835d210a0a8

    customresourcedefinition.apiextensions.k8s.io/patterns.gitops.hybrid-cloud-patterns.io unchanged
    configmap/patterns-operator-config unchanged
    resource mapping not found for name: "patterns-operator" namespace: "openshift-operators" from "STDIN": no matches for kind "SubscriptionNotexistant" in version "operators.coreos.com/v1alpha1"
    ensure CRDs are installed first
    Error from server (NotFound): error when creating "STDIN": namespaces "openshift-operators-notexistant" not found
    make[1]: *** [common/Makefile:71: operator-deploy] Error 1
    make[1]: Leaving directory '/home/michele/Engineering/cloud-patterns/multicloud-gitops'
    make: *** [Makefile:12: operator-deploy] Error 2
