### PR TITLE
Fix validated-schema make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ validate-cluster: ## Do some cluster validations before installing
 validate-schema: ## validates values files against schema in common/clustergroup
 	$(eval VAL_PARAMS := $(shell for i in ./values-*.yaml; do echo -n "$${i} "; done))
 	@echo -n "Validating clustergroup schema of: "
-	@set -e; for i in $(VAL_PARAMS); do echo -n " $$i"; helm template common/clustergroup $(HELM_OPTS) -f "$${i}" >/dev/null; done
+	@set -e; for i in $(VAL_PARAMS); do echo -n " $$i"; helm template oci://quay.io/hybridcloudpatterns/clustergroup $(HELM_OPTS) -f "$${i}" >/dev/null; done
 	@echo
 
 .PHONY: validate-prereq


### PR DESCRIPTION
Since the slimming of common this won't work anymore:

❯ make validate-schema
make -f common/Makefile validate-schema
make[1]: Entering directory '/home/michele/Engineering/cloud-patterns/multicloud-gitops'
Validating clustergroup schema of:  ./values-global.yamlError: repo common not found
make[1]: *** [common/Makefile:162: validate-schema] Error 1
make[1]: Leaving directory '/home/michele/Engineering/cloud-patterns/multicloud-gitops'
make: *** [Makefile:12: validate-schema] Error 2

Fix this to use the oci helm chart:
❯ make validate-schema
make -f common/Makefile validate-schema
make[1]: Entering directory '/home/michele/Engineering/cloud-patterns/multicloud-gitops'
Validating clustergroup schema of:  ./values-global.yamlPulled: quay.io/hybridcloudpatterns/clustergroup:0.9.13
Digest: sha256:725af54c0a5ad8c2235676bbff2785ece62c9929ab58aaf33837aa3f19708ce6
 ./values-group-one.yamlPulled: quay.io/hybridcloudpatterns/clustergroup:0.9.13
Digest: sha256:725af54c0a5ad8c2235676bbff2785ece62c9929ab58aaf33837aa3f19708ce6
 ./values-hub.yamlPulled: quay.io/hybridcloudpatterns/clustergroup:0.9.13
Digest: sha256:725af54c0a5ad8c2235676bbff2785ece62c9929ab58aaf33837aa3f19708ce6

make[1]: Leaving directory '/home/michele/Engineering/cloud-patterns/multicloud-gitops'
