### PR TITLE
update how to make common subtree

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,16 +34,16 @@ main:
 ## Start Here
 
 This repository is never used as standalone. It is usually imported in each pattern as a subtree.
-In order to import the common/ the very first time you can use
-`https://github.com/validatedpatterns/multicloud-gitops/blob/main/common/scripts/make_common_subtree.sh`
+In order to import the common subtree the very first time you can use the script
+[make_common_subtree.sh](scripts/make-common-subtree.sh).
 
 In order to update your common subtree inside your pattern repository you can either use
 `https://github.com/validatedpatterns/utilities/blob/main/scripts/update-common-everywhere.sh` or
-do it manually by doing the following:
+do it manually with the following commands:
 
 ```sh
-git remote add -f upstream-common https://github.com/validatedpatterns/common.git
-git merge -s subtree -Xtheirs -Xsubtree=common upstream-common/main
+git remote add -f common-upstream https://github.com/validatedpatterns/common.git
+git merge -s subtree -Xtheirs -Xsubtree=common common-upstream/main
 ```
 
 ## Secrets

--- a/scripts/make-common-subtree.sh
+++ b/scripts/make-common-subtree.sh
@@ -7,7 +7,7 @@ if [ "$1" = "-h" ]; then
 	echo "$0 <subtree_repo> <subtree_branch> <subtree_remote_name>"
 	echo
 	echo "Run without arguments, the script would run as if these arguments had been passed:"
-	echo "$0 https://github.com/hybrid-cloud-patterns/common.git main common-subtree"
+	echo "$0 https://github.com/validatedpatterns/common.git main common-upstream"
 	echo
 	echo "Please ensure the git subtree command is available. On RHEL/Fedora, the git subtree command"
 	echo "is in a separate package called git-subtree"
@@ -41,7 +41,7 @@ fi
 if [ "$1" ]; then
 	subtree_repo=$1
 else
-	subtree_repo=https://github.com/hybrid-cloud-patterns/common.git
+	subtree_repo=https://github.com/validatedpatterns/common.git
 fi
 
 if [ "$2" ]; then
@@ -53,7 +53,7 @@ fi
 if [ "$3" ]; then
 	subtree_remote=$3
 else
-	subtree_remote=common-subtree
+	subtree_remote=common-upstream
 fi
 
 git diff --quiet || (echo "This script must be run on a clean working tree" && exit 1)


### PR DESCRIPTION
A few small changes in this commit:
* Update README to reference the `make-common-subtree` script in common rather than MCG repo
* Update README and `make-common-subtree` script to use same default remote name for common subtree that we use in our `update-common-everywhere` script.
* Update file name for the script to use dashes rather than underscores for consistency
* Update the name of our GH org to `validatedpatterns`