### PR TITLE
 Infer the git remote from the branch name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,12 +25,14 @@ EXTRA_PLAYBOOK_OPTS ?=
 # INDEX_IMAGES=registry-proxy.engineering.redhat.com/rh-osbs/iib:394248,registry-proxy.engineering.redhat.com/rh-osbs/iib:394249
 INDEX_IMAGES ?=
 
-TARGET_ORIGIN ?= origin
 # This is to ensure that whether we start with a git@ or https:// URL, we end up with an https:// URL
 # This is because we expect to use tokens for repo authentication as opposed to SSH keys
 TARGET_REPO=$(shell git ls-remote --get-url --symref $(TARGET_ORIGIN) | sed -e 's/.*URL:[[:space:]]*//' -e 's%^git@%%' -e 's%^https://%%' -e 's%:%/%' -e 's%^%https://%')
 # git branch --show-current is also available as of git 2.22, but we will use this for compatibility
 TARGET_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
+
+#default to the branch remote
+TARGET_ORIGIN ?= $(shell git config branch.$(TARGET_BRANCH).remote)
 
 UUID_FILE ?= ~/.config/validated-patterns/pattern-uuid
 UUID_HELM_OPTS ?=


### PR DESCRIPTION
 this is better than assuming it's called `origin` because in many cases
 people want to use forks on the same local directory
