### PR TITLE
Double the time we wait for yaml to apply

### DIFF
--- a/scripts/deploy-pattern.sh
+++ b/scripts/deploy-pattern.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -o pipefail
 
-RUNS=10
+RUNS=20
 WAIT=15
 # Retry five times because the CRD might not be fully installed yet
 echo -n "Installing pattern: "


### PR DESCRIPTION
We've seen in some deployments (especially baremetal) that it might take
a few minutes for pods to be up and be healthy. Right now we
wait for 10*15s (2.5mins). Let's wait up to five minutes for yaml to be
able to be applied.
