### PR TITLE
Default TOKEN_NAMESPACE to openshift-operators

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ endif
 # Set the secret name *and* its namespace when deploying from private repositories
 # The format of said secret is documented here: https://argo-cd.readthedocs.io/en/stable/operator-manual/declarative-setup/#repositories
 TOKEN_SECRET ?=
-TOKEN_NAMESPACE ?=
+TOKEN_NAMESPACE ?= openshift-operators
 
 ifeq ($(TOKEN_SECRET),)
   # SSH agents are not created for public repos (repos with no secret token) by the patterns operator so we convert to HTTPS


### PR DESCRIPTION
This way it does not need to be passed explicitely by a user in the
default case. What happens is the secret will be in that namespace and
the patterns-operator will copy it over to the namespaced argo once it
is in place.
