### PR TITLE
fix: mount current directory to podman run

### DIFF
--- a/scripts/pattern-util.sh
+++ b/scripts/pattern-util.sh
@@ -104,11 +104,11 @@ podman run -it --rm --pull=newer \
     -e K8S_AUTH_PASSWORD \
     -e K8S_AUTH_TOKEN \
     ${PKI_HOST_MOUNT_ARGS} \
-    -v "$(pwd)":"$(pwd)" \
+    -v "$(pwd -P)":"$(pwd -P)" \
     -v "${HOME}":"${HOME}" \
     -v "${HOME}":/pattern-home \
     ${PODMAN_ARGS} \
     ${EXTRA_ARGS} \
-    -w "$(pwd)" \
+    -w "$(pwd -P)" \
     "$PATTERN_UTILITY_CONTAINER" \
     $@


### PR DESCRIPTION
This is needed in cases where the repo is not under the home folder (ie
WSL)
resolves #636
